### PR TITLE
Review class Archive API once again

### DIFF
--- a/archive/archive.py
+++ b/archive/archive.py
@@ -104,7 +104,10 @@ class Archive:
 
     def open(self, path):
         self.path = Path(path)
-        self._open()
+        try:
+            self._file = tarfile.open(str(self.path), 'r')
+        except OSError as e:
+            raise ArchiveReadError(str(e))
         ti = self._file.next()
         path = Path(ti.path)
         if path.name != ".manifest.yaml":
@@ -112,12 +115,6 @@ class Archive:
         self.basedir = path.parent
         self.manifest = Manifest(fileobj=self._file.extractfile(ti))
         return self
-
-    def _open(self):
-        try:
-            self._file = tarfile.open(str(self.path), 'r')
-        except OSError as e:
-            raise ArchiveReadError(str(e))
 
     def close(self):
         if self._file:

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -29,9 +29,7 @@ class Archive:
         self.manifest = None
         self._file = None
 
-    @classmethod
-    def create(cls, path, compression, paths, basedir=None, workdir=None):
-        archive = cls()
+    def create(self, path, compression, paths, basedir=None, workdir=None):
         if sys.version_info < (3, 5):
             # The 'x' (exclusive creation) mode was added to tarfile
             # in Python 3.5.
@@ -40,10 +38,10 @@ class Archive:
             mode = 'x:' + compression
         if workdir:
             with tmp_chdir(workdir):
-                archive._create(Path(workdir, path), mode, paths, basedir)
+                self._create(Path(workdir, path), mode, paths, basedir)
         else:
-            archive._create(Path(path), mode, paths, basedir)
-        return archive
+            self._create(Path(path), mode, paths, basedir)
+        return self
 
     def _create(self, path, mode, paths, basedir):
         self.path = path
@@ -104,18 +102,16 @@ class Archive:
                                              "this filename is reserved" % p)
                 tarf.add(str(p), arcname=name, recursive=False)
 
-    @classmethod
-    def open(cls, path):
-        archive = cls()
-        archive.path = Path(path)
-        archive._open()
-        ti = archive._file.next()
+    def open(self, path):
+        self.path = Path(path)
+        self._open()
+        ti = self._file.next()
         path = Path(ti.path)
         if path.name != ".manifest.yaml":
             raise ArchiveIntegrityError("manifest not found")
-        archive.basedir = path.parent
-        archive.manifest = Manifest(fileobj=archive._file.extractfile(ti))
-        return archive
+        self.basedir = path.parent
+        self.manifest = Manifest(fileobj=self._file.extractfile(ti))
+        return self
 
     def _open(self):
         try:

--- a/scripts/archive-tool.py
+++ b/scripts/archive-tool.py
@@ -30,8 +30,8 @@ def create(args):
             args.compression = 'gz'
     if args.compression == 'none':
         args.compression = ''
-    archive = Archive.create(args.archive, args.compression, args.files, 
-                             args.basedir)
+    archive = Archive().create(args.archive, args.compression, args.files, 
+                               args.basedir)
 
 create_parser = subparsers.add_parser('create', help="create the archive")
 create_parser.add_argument('--compression',
@@ -47,7 +47,7 @@ create_parser.set_defaults(func=create)
 
 
 def verify(args):
-    with Archive.open(args.archive) as archive:
+    with Archive().open(args.archive) as archive:
         archive.verify()
 
 verify_parser = subparsers.add_parser('verify',
@@ -77,7 +77,7 @@ def ls_checksum_format(archive, algorithm):
         print("%s  %s" % (fi.checksum[algorithm], fi.path))
 
 def ls(args):
-    with Archive.open(args.archive) as archive:
+    with Archive().open(args.archive) as archive:
         if args.format == 'ls':
             ls_ls_format(archive)
         elif args.format == 'checksum':
@@ -104,7 +104,7 @@ ls_parser.set_defaults(func=ls)
 
 def info(args):
     typename = {"f": "file", "d": "directory", "l": "symbolic link"}
-    with Archive.open(args.archive) as archive:
+    with Archive().open(args.archive) as archive:
         fi = archive.manifest.find(args.entry)
         if not fi:
             raise ArchiveReadError("%s: not found in archive" % args.entry)
@@ -145,7 +145,7 @@ def _matches(fi, entry):
     return True
 
 def check(args):
-    with Archive.open(args.archive) as archive:
+    with Archive().open(args.archive) as archive:
         FileInfo.Checksums = archive.manifest.head["Checksums"]
         file_iter = FileInfo.iterpaths(args.files)
         skip = None

--- a/tests/test_01_create.py
+++ b/tests/test_01_create.py
@@ -74,13 +74,13 @@ def test_create(test_dir, monkeypatch, testcase):
     else:
         paths = ["base"]
         basedir = "base"
-    Archive.create(archive_path, compression, paths, basedir=basedir)
+    Archive().create(archive_path, compression, paths, basedir=basedir)
 
 @pytest.mark.dependency()
 def test_check_manifest(test_dir, dep_testcase):
     compression, abspath = dep_testcase
     archive_path = test_dir / archive_name(compression, abspath)
-    with Archive.open(archive_path) as archive:
+    with Archive().open(archive_path) as archive:
         prefix_dir = test_dir if abspath else None
         head = archive.manifest.head
         assert set(head.keys()) == {"Date", "Generator", "Version", "Checksums"}
@@ -116,5 +116,5 @@ def test_check_content(test_dir, dep_testcase):
 def test_verify(test_dir, dep_testcase):
     compression, abspath = dep_testcase
     archive_path = test_dir / archive_name(compression, abspath)
-    with Archive.open(archive_path) as archive:
+    with Archive().open(archive_path) as archive:
         archive.verify()

--- a/tests/test_02_create_errors.py
+++ b/tests/test_02_create_errors.py
@@ -34,7 +34,7 @@ def test_create_empty(test_dir, archive_name, monkeypatch):
     """
     monkeypatch.chdir(str(test_dir))
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", [], basedir="base")
+        Archive().create(archive_name, "", [], basedir="base")
 
 def test_create_abs_basedir(test_dir, archive_name, monkeypatch):
     """Base dir must be a a relative path.
@@ -42,7 +42,7 @@ def test_create_abs_basedir(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     basedir = test_dir / "base"
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", ["base"], basedir=basedir)
+        Archive().create(archive_name, "", ["base"], basedir=basedir)
 
 def test_create_mixing_abs_rel(test_dir, archive_name, monkeypatch):
     """Mixing absolute and relative paths is not allowed.
@@ -50,7 +50,7 @@ def test_create_mixing_abs_rel(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     paths = [ Path("base", "msg.txt"), test_dir / "base" / "data" ]
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", paths, basedir="base")
+        Archive().create(archive_name, "", paths, basedir="base")
 
 def test_create_rel_not_in_base(test_dir, archive_name, monkeypatch):
     """Relative paths must be in the base directory.
@@ -58,7 +58,7 @@ def test_create_rel_not_in_base(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     paths = [ Path("other", "rnd.dat") ]
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", paths, basedir="base")
+        Archive().create(archive_name, "", paths, basedir="base")
 
 def test_create_norm_path(test_dir, archive_name, monkeypatch):
     """Items in paths must be normalized.  (Issue #6)
@@ -66,7 +66,7 @@ def test_create_norm_path(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     paths = [ "base", "base/../../../etc/passwd" ]
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", paths, basedir="base")
+        Archive().create(archive_name, "", paths, basedir="base")
 
 def test_create_rel_check_basedir(test_dir, archive_name, monkeypatch):
     """Base directory must be a directory.  (Issue #9)
@@ -74,7 +74,7 @@ def test_create_rel_check_basedir(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     p = Path("msg.txt")
     with pytest.raises(ArchiveCreateError):
-        Archive.create(archive_name, "", [p], basedir=p)
+        Archive().create(archive_name, "", [p], basedir=p)
 
 def test_create_rel_no_manifest_file(test_dir, archive_name, monkeypatch):
     """The filename .manifest.yaml is reserved by archive-tools.
@@ -94,6 +94,6 @@ def test_create_rel_no_manifest_file(test_dir, archive_name, monkeypatch):
         print("This is not a YAML file!", file=f)
     try:
         with pytest.raises(ArchiveCreateError):
-            Archive.create(archive_name, "", [base])
+            Archive().create(archive_name, "", [base])
     finally:
         manifest.unlink()

--- a/tests/test_02_create_misc.py
+++ b/tests/test_02_create_misc.py
@@ -32,8 +32,8 @@ def test_create_default_basedir_rel(test_dir, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     archive_path = "archive-rel.tar"
     p = Path("base", "data")
-    Archive.create(archive_path, "", [p])
-    with Archive.open(archive_path) as archive:
+    Archive().create(archive_path, "", [p])
+    with Archive().open(archive_path) as archive:
         assert archive.basedir == Path("base")
         check_manifest(archive.manifest, **testdata)
         archive.verify()
@@ -44,8 +44,8 @@ def test_create_default_basedir_abs(test_dir, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     archive_path = "archive-abs.tar"
     p = test_dir / Path("base", "data")
-    Archive.create(archive_path, "", [p])
-    with Archive.open(archive_path) as archive:
+    Archive().create(archive_path, "", [p])
+    with Archive().open(archive_path) as archive:
         assert archive.basedir == Path("archive-abs")
         check_manifest(archive.manifest, prefix_dir=test_dir, **testdata)
         archive.verify()
@@ -60,8 +60,8 @@ def test_create_sorted(test_dir, monkeypatch):
         with p.open("wt") as f:
             print("Some content for file %s" % p, file=f)
     try:
-        Archive.create(archive_path, "", files)
-        with Archive.open(archive_path) as archive:
+        Archive().create(archive_path, "", files)
+        with Archive().open(archive_path) as archive:
             assert [fi.path for fi in archive.manifest] == sorted(files)
             archive.verify()
     finally:

--- a/tests/test_02_verify_errors.py
+++ b/tests/test_02_verify_errors.py
@@ -54,7 +54,7 @@ def test_verify_missing_manifest(test_data, archive_name):
     with tarfile.open(archive_name, "w") as tarf:
         tarf.add("base")
     with pytest.raises(ArchiveIntegrityError) as err:
-        with Archive.open(archive_name) as archive:
+        with Archive().open(archive_name) as archive:
             pass
     assert "manifest not found" in str(err.value)
 
@@ -64,7 +64,7 @@ def test_verify_missing_file(test_data, archive_name):
     path.unlink()
     os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: missing" % path in str(err.value)
@@ -73,7 +73,7 @@ def test_verify_wrong_mode_file(test_data, archive_name):
     path = Path("base", "data", "rnd.dat")
     path.chmod(0o644)
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong mode" % path in str(err.value)
@@ -82,7 +82,7 @@ def test_verify_wrong_mode_dir(test_data, archive_name):
     path = Path("base", "data")
     path.chmod(0o755)
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong mode" % path in str(err.value)
@@ -92,7 +92,7 @@ def test_verify_wrong_mtime(test_data, archive_name):
     hour_ago = time.time() - 3600
     os.utime(str(path), times=(hour_ago, hour_ago))
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong modification time" % path in str(err.value)
@@ -108,7 +108,7 @@ def test_verify_wrong_type(test_data, archive_name):
     os.utime(str(path), times=(mtime, mtime))
     os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong type" % path in str(err.value)
@@ -124,12 +124,12 @@ def test_verify_wrong_checksum(test_data, archive_name):
     path.chmod(mode)
     os.utime(str(path), times=(mtime, mtime))
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: checksum" % path in str(err.value)
 
 def test_verify_ok(test_data, archive_name):
     create_archive(archive_name)
-    with Archive.open(archive_name) as archive:
+    with Archive().open(archive_name) as archive:
         archive.verify()

--- a/tests/test_02_verify_errors.py
+++ b/tests/test_02_verify_errors.py
@@ -56,7 +56,7 @@ def test_verify_missing_manifest(test_data, archive_name):
     with pytest.raises(ArchiveIntegrityError) as err:
         with Archive().open(archive_name) as archive:
             pass
-    assert "manifest not found" in str(err.value)
+    assert ".manifest.yaml not found" in str(err.value)
 
 def test_verify_missing_file(test_data, archive_name):
     path = Path("base", "msg.txt")

--- a/tests/test_03_cli.py
+++ b/tests/test_03_cli.py
@@ -76,7 +76,7 @@ def test_cli_create(test_dir, monkeypatch, testcase):
     args = ["create", "--compression", compression, "--basedir", basedir,
             archive_path, paths]
     callscript("archive-tool.py", args)
-    with Archive.open(archive_path) as archive:
+    with Archive().open(archive_path) as archive:
         assert str(archive.basedir) == basedir
         prefix_dir = test_dir if abspath else None
         check_manifest(archive.manifest, prefix_dir=prefix_dir, **testdata)

--- a/tests/test_03_cli_check.py
+++ b/tests/test_03_cli_check.py
@@ -32,7 +32,7 @@ all_test_files = {
 @pytest.fixture(scope="module")
 def test_dir(tmpdir):
     setup_testdata(tmpdir, **testdata)
-    Archive.create("archive.tar", "", ["base"], workdir=tmpdir)
+    Archive().create("archive.tar", "", ["base"], workdir=tmpdir)
     return tmpdir
 
 @pytest.fixture(scope="function")

--- a/tests/test_03_cli_error.py
+++ b/tests/test_03_cli_error.py
@@ -178,7 +178,7 @@ def test_cli_integrity_no_manifest(test_dir, archive_name, monkeypatch):
         assert exc_info.value.returncode == 3
         f.seek(0)
         line = f.readline()
-        assert "manifest not found" in line
+        assert ".manifest.yaml not found" in line
 
 def test_cli_integrity_missing_file(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))


### PR DESCRIPTION
Amend the changes to the `class Archive` API done in #23: change the class methods `open()` and `create()` into normal instance methods.  This makes it easier to adapt the behavior.  This requires a minor modification of calling code from
```python
archive = Archive.create(...)
```
to
```python
archive = Archive().create(...)
```
But it also makes it possible to manipulate the archive object before calling `create()`:
```python
archive = Archive()
# do something with the archive object ...
archive.create(...)
```

Furthermore, add methods `add_metadata()` and `get_metadata()` to add and to retrieve custom metadata to and from archives.