### PR TITLE
Drop support for strings in file name arguments of Archive methods.

### DIFF
--- a/archive/archive.py
+++ b/archive/archive.py
@@ -68,9 +68,9 @@ class Archive:
             mode = 'x:' + compression
         if workdir:
             with tmp_chdir(workdir):
-                self._create(Path(workdir, path), mode, paths, basedir, dedup)
+                self._create(workdir / path, mode, paths, basedir, dedup)
         else:
-            self._create(Path(path), mode, paths, basedir, dedup)
+            self._create(path, mode, paths, basedir, dedup)
         return self
 
     def _create(self, path, mode, paths, basedir, dedup):
@@ -118,13 +118,13 @@ class Archive:
         if not paths:
             raise ArchiveCreateError("refusing to create an empty archive")
         if not basedir:
-            p = Path(paths[0])
+            p = paths[0]
             if p.is_absolute():
                 self.basedir = Path(self.path.name.split('.')[0])
             else:
                 self.basedir = Path(p.parts[0])
         else:
-            self.basedir = Path(basedir)
+            self.basedir = basedir
         if self.basedir.is_absolute():
             raise ArchiveCreateError("basedir must be relative")
         # We allow two different cases: either
@@ -136,7 +136,6 @@ class Archive:
             if not _is_normalized(p):
                 raise ArchiveCreateError("invalid path %s: must be normalized" 
                                          % p)
-            p = Path(p)
             if abspath is None:
                 abspath = p.is_absolute()
             else:
@@ -200,7 +199,7 @@ class Archive:
         self._metadata.insert(0, md)
 
     def open(self, path):
-        self.path = Path(path)
+        self.path = path
         try:
             self._file = tarfile.open(str(self.path), 'r')
         except OSError as e:

--- a/scripts/archive-tool.py
+++ b/scripts/archive-tool.py
@@ -66,7 +66,7 @@ create_parser = subparsers.add_parser('create', help="create the archive")
 create_parser.add_argument('--compression',
                            choices=['none', 'gz', 'bz2', 'xz'],
                            help=("compression mode"))
-create_parser.add_argument('--basedir',
+create_parser.add_argument('--basedir', type=Path,
                            help=("common base directory in the archive"))
 create_parser.add_argument('--deduplicate',
                            choices=[d.value for d in DedupMode], default='link',

--- a/tests/test_02_create.py
+++ b/tests/test_02_create.py
@@ -68,13 +68,13 @@ def test_create(test_dir, monkeypatch, testcase):
     compression, abspath = testcase
     require_compression(compression)
     monkeypatch.chdir(str(test_dir))
-    archive_path = archive_name(compression, abspath)
+    archive_path = Path(archive_name(compression, abspath))
     if abspath:
         paths = [test_dir / "base"]
-        basedir = "archive"
+        basedir = Path("archive")
     else:
-        paths = ["base"]
-        basedir = "base"
+        paths = [Path("base")]
+        basedir = Path("base")
     Archive().create(archive_path, compression, paths, basedir=basedir)
 
 @pytest.mark.dependency()

--- a/tests/test_03_create_dedup.py
+++ b/tests/test_03_create_dedup.py
@@ -68,8 +68,8 @@ def dep_testcase(request, testcase):
 def test_create(test_dir, monkeypatch, testcase):
     dedup = testcase
     monkeypatch.chdir(str(test_dir))
-    archive_path = archive_name(dedup)
-    paths = ["base"]
+    archive_path = Path(archive_name(dedup))
+    paths = [Path("base")]
     Archive().create(archive_path, '', paths, dedup=dedup)
 
 @pytest.mark.dependency()

--- a/tests/test_03_create_errors.py
+++ b/tests/test_03_create_errors.py
@@ -35,15 +35,16 @@ def test_create_empty(test_dir, archive_name, monkeypatch):
     """
     monkeypatch.chdir(str(test_dir))
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", [], basedir="base")
+        Archive().create(Path(archive_name), "", [], basedir=Path("base"))
 
 def test_create_abs_basedir(test_dir, archive_name, monkeypatch):
     """Base dir must be a a relative path.
     """
     monkeypatch.chdir(str(test_dir))
+    paths = [Path("base")]
     basedir = test_dir / "base"
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", ["base"], basedir=basedir)
+        Archive().create(Path(archive_name), "", paths, basedir=basedir)
 
 def test_create_mixing_abs_rel(test_dir, archive_name, monkeypatch):
     """Mixing absolute and relative paths is not allowed.
@@ -51,7 +52,7 @@ def test_create_mixing_abs_rel(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     paths = [ Path("base", "msg.txt"), test_dir / "base" / "data" ]
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", paths, basedir="base")
+        Archive().create(Path(archive_name), "", paths, basedir=Path("base"))
 
 def test_create_rel_not_in_base(test_dir, archive_name, monkeypatch):
     """Relative paths must be in the base directory.
@@ -59,15 +60,15 @@ def test_create_rel_not_in_base(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     paths = [ Path("other", "rnd.dat") ]
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", paths, basedir="base")
+        Archive().create(Path(archive_name), "", paths, basedir=Path("base"))
 
 def test_create_norm_path(test_dir, archive_name, monkeypatch):
     """Items in paths must be normalized.  (Issue #6)
     """
     monkeypatch.chdir(str(test_dir))
-    paths = [ "base", "base/../../../etc/passwd" ]
+    paths = [ Path("base"), Path("base/../../../etc/passwd") ]
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", paths, basedir="base")
+        Archive().create(Path(archive_name), "", paths, basedir=Path("base"))
 
 def test_create_rel_check_basedir(test_dir, archive_name, monkeypatch):
     """Base directory must be a directory.  (Issue #9)
@@ -75,7 +76,7 @@ def test_create_rel_check_basedir(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     p = Path("msg.txt")
     with pytest.raises(ArchiveCreateError):
-        Archive().create(archive_name, "", [p], basedir=p)
+        Archive().create(Path(archive_name), "", [p], basedir=p)
 
 def test_create_rel_no_manifest_file(test_dir, archive_name, monkeypatch):
     """The filename .manifest.yaml is reserved by archive-tools.
@@ -95,7 +96,7 @@ def test_create_rel_no_manifest_file(test_dir, archive_name, monkeypatch):
         print("This is not a YAML file!", file=f)
     try:
         with pytest.raises(ArchiveCreateError):
-            Archive().create(archive_name, "", [base])
+            Archive().create(Path(archive_name), "", [base])
     finally:
         manifest.unlink()
 
@@ -111,7 +112,7 @@ def test_create_duplicate_metadata(test_dir, archive_name, monkeypatch):
         tmpf.seek(0)
         with pytest.raises(ArchiveCreateError) as err:
             archive.add_metadata(".manifest.yaml", tmpf)
-            archive.create(archive_name, "", [p])
+            archive.create(Path(archive_name), "", [p])
         assert "duplicate metadata" in str(err.value)
 
 def test_create_metadata_vs_content(test_dir, archive_name, monkeypatch):
@@ -126,5 +127,5 @@ def test_create_metadata_vs_content(test_dir, archive_name, monkeypatch):
         tmpf.seek(0)
         with pytest.raises(ArchiveCreateError) as err:
             archive.add_metadata("msg.txt", tmpf)
-            archive.create(archive_name, "", [p])
+            archive.create(Path(archive_name), "", [p])
         assert "filename is reserved" in str(err.value)

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -43,7 +43,7 @@ def test_create_default_basedir_abs(test_dir, monkeypatch):
     """Check the default basedir with absolute paths.  (Issue #8)
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = "archive-abs.tar"
+    archive_path = Path("archive-abs.tar")
     p = test_dir / Path("base", "data")
     Archive().create(archive_path, "", [p])
     with Archive().open(archive_path) as archive:
@@ -55,7 +55,7 @@ def test_create_sorted(test_dir, monkeypatch):
     """The entries in the manifest should be sorted.  (Issue #11)
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = "archive-sort.tar"
+    archive_path = Path("archive-sort.tar")
     files = [ Path("base", fn) for fn in ("c", "a", "d", "b") ]
     for p in files:
         with p.open("wt") as f:
@@ -73,7 +73,7 @@ def test_create_custom_metadata(test_dir, monkeypatch):
     """Add additional custom metadata to the archive.
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = "archive-custom-md.tar"
+    archive_path = Path("archive-custom-md.tar")
     p = Path("base", "data")
     with TemporaryFile(dir=str(test_dir)) as tmpf:
         archive = Archive()

--- a/tests/test_03_verify_errors.py
+++ b/tests/test_03_verify_errors.py
@@ -56,7 +56,7 @@ def test_verify_missing_manifest(test_data, archive_name):
     with tarfile.open(archive_name, "w") as tarf:
         tarf.add("base")
     with pytest.raises(ArchiveIntegrityError) as err:
-        with Archive().open(archive_name) as archive:
+        with Archive().open(Path(archive_name)) as archive:
             pass
     assert ".manifest.yaml not found" in str(err.value)
 
@@ -73,7 +73,7 @@ def test_verify_missing_metadata_item(test_data, archive_name):
             ti.mode = stat.S_IFREG | stat.S_IMODE(0o444)
             tarf.addfile(ti, tmpf)
         tarf.add("base")
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "'base/.msg.txt' not found" in str(err.value)
@@ -84,7 +84,7 @@ def test_verify_missing_file(test_data, archive_name):
     path.unlink()
     os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: missing" % path in str(err.value)
@@ -93,7 +93,7 @@ def test_verify_wrong_mode_file(test_data, archive_name):
     path = Path("base", "data", "rnd.dat")
     path.chmod(0o644)
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong mode" % path in str(err.value)
@@ -102,7 +102,7 @@ def test_verify_wrong_mode_dir(test_data, archive_name):
     path = Path("base", "data")
     path.chmod(0o755)
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong mode" % path in str(err.value)
@@ -112,7 +112,7 @@ def test_verify_wrong_mtime(test_data, archive_name):
     hour_ago = time.time() - 3600
     os.utime(str(path), times=(hour_ago, hour_ago))
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong modification time" % path in str(err.value)
@@ -128,7 +128,7 @@ def test_verify_wrong_type(test_data, archive_name):
     os.utime(str(path), times=(mtime, mtime))
     os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: wrong type" % path in str(err.value)
@@ -144,12 +144,12 @@ def test_verify_wrong_checksum(test_data, archive_name):
     path.chmod(mode)
     os.utime(str(path), times=(mtime, mtime))
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
             archive.verify()
         assert "%s: checksum" % path in str(err.value)
 
 def test_verify_ok(test_data, archive_name):
     create_archive(archive_name)
-    with Archive().open(archive_name) as archive:
+    with Archive().open(Path(archive_name)) as archive:
         archive.verify()

--- a/tests/test_04_cli_check.py
+++ b/tests/test_04_cli_check.py
@@ -33,7 +33,7 @@ all_test_files = {
 @pytest.fixture(scope="module")
 def test_dir(tmpdir):
     setup_testdata(tmpdir, **testdata)
-    Archive().create("archive.tar", "", ["base"], workdir=tmpdir)
+    Archive().create(Path("archive.tar"), "", [Path("base")], workdir=tmpdir)
     return tmpdir
 
 @pytest.fixture(scope="function")
@@ -217,7 +217,7 @@ def test_check_extract_archive_custom_metadata(test_dir, request, monkeypatch):
         tmpf.write("Hello world!\n".encode("ascii"))
         tmpf.seek(0)
         archive.add_metadata(".msg.txt", tmpf)
-        archive.create(archive_path, "", ["base"], workdir=test_dir)
+        archive.create(archive_path, "", [Path("base")], workdir=test_dir)
     check_dir = test_dir / request.function.__name__
     check_dir.mkdir()
     monkeypatch.chdir(str(check_dir))

--- a/tests/test_04_cli_create_dedup.py
+++ b/tests/test_04_cli_create_dedup.py
@@ -69,7 +69,7 @@ def test_cli_create(test_dir, monkeypatch, testcase):
     basedir = "base"
     args = ["create", "--deduplicate", dedup.value, archive_path, basedir]
     callscript("archive-tool.py", args)
-    with Archive().open(archive_path) as archive:
+    with Archive().open(Path(archive_path)) as archive:
         assert str(archive.basedir) == basedir
         check_manifest(archive.manifest, **testdata)
 


### PR DESCRIPTION
Drop support for strings in the file name arguments `path`, `paths`, `basedir`, and `workdir` of the `class Archive` methods `create()` and `open()`.  These arguments require `Path` objects now.