### PR TITLE
Diff functionality

### DIFF
--- a/archive/cli/__init__.py
+++ b/archive/cli/__init__.py
@@ -41,7 +41,7 @@ def archive_tool():
     if not hasattr(args, "func"):
         argparser.error("subcommand is required")
     try:
-        args.func(args)
+        sys.exit(args.func(args))
     except ArgError as e:
         argparser.error(str(e))
     except ArchiveError as e:

--- a/archive/cli/__init__.py
+++ b/archive/cli/__init__.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from archive.exception import *
 
-subcmds = [ "create", "verify", "ls", "info", "check", ]
+subcmds = [ "create", "verify", "ls", "info", "check", "diff", ]
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
     """Display ArchiveWarning in a somewhat more user friendly manner.

--- a/archive/cli/check.py
+++ b/archive/cli/check.py
@@ -50,6 +50,7 @@ def check(args):
                     print(str(fi.path))
                 if fi.is_dir():
                     skip = True
+    return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('check',

--- a/archive/cli/create.py
+++ b/archive/cli/create.py
@@ -25,6 +25,7 @@ def create(args):
     archive = Archive().create(args.archive, args.compression, args.files, 
                                basedir=args.basedir, excludes=args.exclude, 
                                dedup=DedupMode(args.deduplicate))
+    return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('create', help="create the archive")

--- a/archive/cli/diff.py
+++ b/archive/cli/diff.py
@@ -37,8 +37,7 @@ def diff(args):
     algorithm = _common_checksum(archive1.manifest, archive2.manifest)
     # In principle, we might rely on the fact that the manifest of an
     # archive is always sorted at creation time.  On the other hand,
-    # as we need to rely on this, we sort them again to be on the safe
-    # side.
+    # as we depend on this, we sort them again to be on the safe side.
     archive1.manifest.sort()
     archive2.manifest.sort()
     it1 = iter(archive1.manifest)

--- a/archive/cli/diff.py
+++ b/archive/cli/diff.py
@@ -74,6 +74,15 @@ def diff(args):
                     print("Files %s:%s and %s:%s differ"
                           % (archive1.path, fi1.path, archive2.path, fi2.path))
                     status = max(status, 101)
+                elif args.report_meta and (fi1.uid != fi2.uid or
+                                           fi1.uname != fi2.uname or
+                                           fi1.gid != fi2.gid or
+                                           fi1.gname != fi2.gname or
+                                           fi1.mode != fi2.mode or
+                                           int(fi1.mtime) != int(fi2.mtime)):
+                    print("File system metadata for %s:%s and %s:%s differ"
+                          % (archive1.path, fi1.path, archive2.path, fi2.path))
+                    status = max(status, 100)
             fi1 = _next(it1)
             fi2 = _next(it2)
     return status
@@ -82,6 +91,8 @@ def add_parser(subparsers):
     parser = subparsers.add_parser('diff',
                                    help=("show the differences between "
                                          "two archives"))
+    parser.add_argument('--report-meta', action='store_true',
+                        help=("also show differences in file system metadata"))
     parser.add_argument('archive1', type=Path,
                         help=("first archive to compare"))
     parser.add_argument('archive2', type=Path,

--- a/archive/cli/diff.py
+++ b/archive/cli/diff.py
@@ -1,0 +1,90 @@
+"""Implement the diff subcommand.
+"""
+
+from pathlib import Path
+from archive.archive import Archive
+from archive.exception import ArchiveReadError
+
+
+def _common_checksum(manifest1, manifest2):
+    for algorithm in manifest1.checksums:
+        if algorithm in manifest2.checksums:
+            return algorithm
+    else:
+        raise ArchiveReadError("No common checksum algorithm, "
+                               "cannot compare archive content.")
+
+def _next(it):
+    try:
+        return next(it)
+    except StopIteration:
+        return None
+
+def _relpath(fi, basedir):
+    if fi is not None:
+        if fi.path.is_absolute():
+            return fi.path
+        else:
+            return fi.path.relative_to(basedir)
+    else:
+        return None
+
+def diff(args):
+    archive1 = Archive().open(args.archive1)
+    archive1.close()
+    archive2 = Archive().open(args.archive2)
+    archive2.close()
+    algorithm = _common_checksum(archive1.manifest, archive2.manifest)
+    # In principle, we might rely on the fact that the manifest of an
+    # archive is always sorted at creation time.  On the other hand,
+    # as we need to rely on this, we sort them again to be on the safe
+    # side.
+    archive1.manifest.sort()
+    archive2.manifest.sort()
+    it1 = iter(archive1.manifest)
+    it2 = iter(archive2.manifest)
+    fi1 = _next(it1)
+    fi2 = _next(it2)
+    status = 0
+    while True:
+        path1 = _relpath(fi1, archive1.basedir)
+        path2 = _relpath(fi2, archive2.basedir)
+        if path1 is None and path2 is None:
+            break
+        elif path1 is None or path1 > path2:
+            print("Only in %s: %s" % (archive2.path, fi2.path))
+            fi2 = _next(it2)
+            status = max(status, 102)
+        elif path2 is None or path2 > path1:
+            print("Only in %s: %s" % (archive1.path, fi1.path))
+            fi1 = _next(it1)
+            status = max(status, 102)
+        else:
+            assert path1 == path2
+            if fi1.type != fi2.type:
+                print("Entries %s:%s and %s:%s have different type"
+                      % (archive1.path, fi1.path, archive2.path, fi2.path))
+                status = max(status, 102)
+            elif fi1.type == "l":
+                if fi1.target != fi2.target:
+                    print("Symbol links %s:%s and %s:%s have different target"
+                          % (archive1.path, fi1.path, archive2.path, fi2.path))
+                    status = max(status, 101)
+            elif fi1.type == "f":
+                if fi1.checksum[algorithm] != fi2.checksum[algorithm]:
+                    print("Files %s:%s and %s:%s differ"
+                          % (archive1.path, fi1.path, archive2.path, fi2.path))
+                    status = max(status, 101)
+            fi1 = _next(it1)
+            fi2 = _next(it2)
+    return status
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser('diff',
+                                   help=("show the differences between "
+                                         "two archives"))
+    parser.add_argument('archive1', type=Path,
+                        help=("first archive to compare"))
+    parser.add_argument('archive2', type=Path,
+                        help=("second archive to compare"))
+    parser.set_defaults(func=diff)

--- a/archive/cli/diff.py
+++ b/archive/cli/diff.py
@@ -70,6 +70,9 @@ def diff(args):
                           % (archive1.path, fi1.path, archive2.path, fi2.path))
                     status = max(status, 101)
             elif fi1.type == "f":
+                # Note: we don't need to compare the size, because if
+                # the size differs, it's mostly certain that also the
+                # checksums do.
                 if fi1.checksum[algorithm] != fi2.checksum[algorithm]:
                     print("Files %s:%s and %s:%s differ"
                           % (archive1.path, fi1.path, archive2.path, fi2.path))

--- a/archive/cli/info.py
+++ b/archive/cli/info.py
@@ -27,6 +27,7 @@ def info(args):
         if fi.is_symlink():
             infolines.append("Target: %s" % fi.target)
         print(*infolines, sep="\n")
+    return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('info',

--- a/archive/cli/ls.py
+++ b/archive/cli/ls.py
@@ -39,6 +39,7 @@ def ls(args):
             ls_checksum_format(archive, args.checksum)
         else:
             raise ValueError("invalid format '%s'" % args.format)
+    return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('ls', help="list files in the archive")

--- a/archive/cli/verify.py
+++ b/archive/cli/verify.py
@@ -8,6 +8,7 @@ from archive.archive import Archive
 def verify(args):
     with Archive().open(args.archive) as archive:
         archive.verify()
+    return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('verify',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,7 +158,8 @@ def check_manifest(manifest, prefix_dir=None, dirs=[], files=[], symlinks=[]):
         elif entry["Type"] == "l":
             assert fileinfo.target == entry["Target"]
 
-def callscript(scriptname, args, stdin=None, stdout=None, stderr=None):
+def callscript(scriptname, args, returncode=0,
+               stdin=None, stdout=None, stderr=None):
     try:
         script_dir = os.environ['BUILD_SCRIPTS_DIR']
     except KeyError:
@@ -166,4 +167,5 @@ def callscript(scriptname, args, stdin=None, stdout=None, stderr=None):
     script = Path(script_dir, scriptname)
     cmd = [sys.executable, str(script)] + args
     print("\n>", *cmd)
-    subprocess.check_call(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
+    retcode = subprocess.call(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
+    assert retcode == returncode

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -280,7 +280,6 @@ def test_diff_basedir_mod_file(test_data, request, monkeypatch):
                           % (archive_ref_path, p, archive_path, pn))
 
 @pytest.mark.parametrize("abspath", [False, True])
-@pytest.mark.xfail(reason="--skip-dir-content flag not yet implemented")
 def test_diff_dircontent(test_data, request, monkeypatch, abspath):
     """Diff two archives with one subdirectory missing.
     """

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -151,3 +151,12 @@ def test_diff_metadata(test_dir, copy_data, archive_name, monkeypatch):
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
         assert get_output(f) == []
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", "--report-meta",
+                str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, returncode=100, stdout=f)
+        f.seek(0)
+        out = get_output(f)
+        assert len(out) == 1
+        assert out[0] == ("File system metadata for %s:%s and %s:%s differ"
+                          % (archive_ref_path, p, archive_path, p))

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -1,0 +1,137 @@
+"""Test the diff subcommand in the command line tool.
+"""
+
+from pathlib import Path
+import shutil
+from tempfile import TemporaryFile
+from archive import Archive
+import pytest
+from conftest import gettestdata, setup_testdata, callscript
+
+# Setup a directory with some test data to be put into an archive.
+# Make sure that we have all kind of different things in there.
+testdata = {
+    "dirs": [
+        (Path("base"), 0o755),
+        (Path("base", "data"), 0o750),
+        (Path("base", "empty"), 0o755),
+    ],
+    "files": [
+        (Path("base", "msg.txt"), 0o644),
+        (Path("base", "data", "rnd.dat"), 0o640),
+        (Path("base", "rnd.dat"), 0o600),
+    ],
+    "symlinks": [
+        (Path("base", "s.dat"), Path("data", "rnd.dat")),
+    ]
+}
+
+@pytest.fixture(scope="module")
+def test_dir(tmpdir):
+    setup_testdata(tmpdir, **testdata)
+    Archive().create(Path("archive.tar"), "", [Path("base")], workdir=tmpdir)
+    return tmpdir
+
+@pytest.fixture(scope="function")
+def copy_data(request, test_dir):
+    copy_dir = test_dir / request.function.__name__
+    shutil.copytree(str(test_dir / "base"), str(copy_dir / "base"), 
+                    symlinks=True)
+    return copy_dir
+
+def get_output(fileobj):
+    out = []
+    while True:
+        line = fileobj.readline()
+        if not line:
+            break
+        out.append(line.strip())
+    return out
+
+def test_diff_equal(test_dir, copy_data, archive_name, monkeypatch):
+    """Diff two archives having equal content.
+    """
+    monkeypatch.chdir(str(copy_data))
+    archive_ref_path = test_dir / "archive.tar"
+    archive_path = test_dir / (archive_name + ".bz2")
+    Archive().create(archive_path, "bz2", [Path("base")])
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, stdout=f)
+        f.seek(0)
+        assert get_output(f) == []
+
+def test_diff_wrong_type(test_dir, copy_data, archive_name, monkeypatch):
+    """Diff two archives with one entry having a wrong type.
+    """
+    monkeypatch.chdir(str(copy_data))
+    p = Path("base", "rnd.dat")
+    p.unlink()
+    p.symlink_to(Path("data", "rnd.dat"))
+    archive_ref_path = test_dir / "archive.tar"
+    archive_path = test_dir / (archive_name + ".bz2")
+    Archive().create(archive_path, "bz2", [Path("base")])
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, returncode=102, stdout=f)
+        f.seek(0)
+        out = get_output(f)
+        assert len(out) == 1
+        assert out[0] == ("Entries %s:%s and %s:%s have different type"
+                          % (archive_ref_path, p, archive_path, p))
+
+def test_diff_modified_file(test_dir, copy_data, archive_name, monkeypatch):
+    """Diff two archives having one file's content modified.
+    """
+    monkeypatch.chdir(str(copy_data))
+    p = Path("base", "rnd.dat")
+    shutil.copy(str(gettestdata("rnd2.dat")), str(p))
+    archive_ref_path = test_dir / "archive.tar"
+    archive_path = test_dir / (archive_name + ".bz2")
+    Archive().create(archive_path, "bz2", [Path("base")])
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, returncode=101, stdout=f)
+        f.seek(0)
+        out = get_output(f)
+        assert len(out) == 1
+        assert out[0] == ("Files %s:%s and %s:%s differ"
+                          % (archive_ref_path, p, archive_path, p))
+
+def test_diff_symlink_target(test_dir, copy_data, archive_name, monkeypatch):
+    """Diff two archives having one symlink's target modified.
+    """
+    monkeypatch.chdir(str(copy_data))
+    p = Path("base", "s.dat")
+    p.unlink()
+    p.symlink_to(Path("msg.txt"))
+    archive_ref_path = test_dir / "archive.tar"
+    archive_path = test_dir / (archive_name + ".bz2")
+    Archive().create(archive_path, "bz2", [Path("base")])
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, returncode=101, stdout=f)
+        f.seek(0)
+        out = get_output(f)
+        assert len(out) == 1
+        assert out[0] == ("Symbol links %s:%s and %s:%s have different target"
+                          % (archive_ref_path, p, archive_path, p))
+
+def test_diff_missing_files(test_dir, copy_data, archive_name, monkeypatch):
+    """Diff two archives having one file's name changed.
+    """
+    monkeypatch.chdir(str(copy_data))
+    p1 = Path("base", "rnd.dat")
+    p2 = Path("base", "a.dat")
+    p1.rename(p2)
+    archive_ref_path = test_dir / "archive.tar"
+    archive_path = test_dir / (archive_name + ".bz2")
+    Archive().create(archive_path, "bz2", [Path("base")])
+    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        args = ["diff", str(archive_ref_path), str(archive_path)]
+        callscript("archive-tool.py", args, returncode=102, stdout=f)
+        f.seek(0)
+        out = get_output(f)
+        assert len(out) == 2
+        assert out[0] == "Only in %s: %s" % (archive_path, p2)
+        assert out[1] == "Only in %s: %s" % (archive_ref_path, p1)

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import shutil
 from tempfile import TemporaryFile
 from archive import Archive
+from archive.tools import tmp_chdir
 import pytest
 from conftest import gettestdata, setup_testdata, callscript
 
@@ -29,15 +30,22 @@ testdata = {
 @pytest.fixture(scope="module")
 def test_dir(tmpdir):
     setup_testdata(tmpdir, **testdata)
-    Archive().create(Path("archive.tar"), "", [Path("base")], workdir=tmpdir)
+    with tmp_chdir(tmpdir):
+        Archive().create(Path("archive-rel.tar"), "", [Path("base")])
+        Archive().create(Path("archive-abs.tar"), "", [tmpdir / "base"])
     return tmpdir
 
 @pytest.fixture(scope="function")
 def test_data(request, test_dir):
     shutil.rmtree(str(test_dir / "base"), ignore_errors=True)
-    with Archive().open(test_dir / "archive.tar") as archive:
+    with Archive().open(test_dir / "archive-rel.tar") as archive:
         archive.extract(test_dir)
     return test_dir
+
+def archive_name(request, abspath):
+    fname = request.function.__name__
+    absflag = "abs" if abspath else "rel"
+    return Path("archive-%s-%s.tar.bz2" % (fname, absflag))
 
 def get_output(fileobj):
     out = []
@@ -48,28 +56,40 @@ def get_output(fileobj):
         out.append(line.strip())
     return out
 
-def test_diff_equal(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_equal(test_data, request, monkeypatch, abspath):
     """Diff two archives having equal content.
     """
     monkeypatch.chdir(str(test_data))
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
         assert get_output(f) == []
 
-def test_diff_modified_file(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_modified_file(test_data, request, monkeypatch, abspath):
     """Diff two archives having one file's content modified.
     """
     monkeypatch.chdir(str(test_data))
-    p = Path("base", "rnd.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    p = base_dir / "rnd.dat"
     shutil.copy(str(gettestdata("rnd2.dat")), str(p))
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=101, stdout=f)
@@ -79,16 +99,22 @@ def test_diff_modified_file(test_data, archive_name, monkeypatch):
         assert out[0] == ("Files %s:%s and %s:%s differ"
                           % (archive_ref_path, p, archive_path, p))
 
-def test_diff_symlink_target(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_symlink_target(test_data, request, monkeypatch, abspath):
     """Diff two archives having one symlink's target modified.
     """
     monkeypatch.chdir(str(test_data))
-    p = Path("base", "s.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    p = base_dir / "s.dat"
     p.unlink()
     p.symlink_to(Path("msg.txt"))
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=101, stdout=f)
@@ -98,16 +124,22 @@ def test_diff_symlink_target(test_data, archive_name, monkeypatch):
         assert out[0] == ("Symbol links %s:%s and %s:%s have different target"
                           % (archive_ref_path, p, archive_path, p))
 
-def test_diff_wrong_type(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_wrong_type(test_data, request, monkeypatch, abspath):
     """Diff two archives with one entry having a wrong type.
     """
     monkeypatch.chdir(str(test_data))
-    p = Path("base", "rnd.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    p = base_dir / "rnd.dat"
     p.unlink()
     p.symlink_to(Path("data", "rnd.dat"))
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
@@ -117,16 +149,22 @@ def test_diff_wrong_type(test_data, archive_name, monkeypatch):
         assert out[0] == ("Entries %s:%s and %s:%s have different type"
                           % (archive_ref_path, p, archive_path, p))
 
-def test_diff_missing_files(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_missing_files(test_data, request, monkeypatch, abspath):
     """Diff two archives having one file's name changed.
     """
     monkeypatch.chdir(str(test_data))
-    p1 = Path("base", "rnd.dat")
-    p2 = Path("base", "a.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    p1 = base_dir / "rnd.dat"
+    p2 = base_dir / "a.dat"
     p1.rename(p2)
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
@@ -136,18 +174,24 @@ def test_diff_missing_files(test_data, archive_name, monkeypatch):
         assert out[0] == "Only in %s: %s" % (archive_path, p2)
         assert out[1] == "Only in %s: %s" % (archive_ref_path, p1)
 
-def test_diff_mult(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_mult(test_data, request, monkeypatch, abspath):
     """Diff two archives having multiple differences.
     """
     monkeypatch.chdir(str(test_data))
-    pm = Path("base", "data", "rnd.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    pm = base_dir / "data" / "rnd.dat"
     shutil.copy(str(gettestdata("rnd2.dat")), str(pm))
-    p1 = Path("base", "msg.txt")
-    p2 = Path("base", "o.txt")
+    p1 = base_dir / "msg.txt"
+    p2 = base_dir / "o.txt"
     p1.rename(p2)
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
@@ -159,16 +203,22 @@ def test_diff_mult(test_data, archive_name, monkeypatch):
         assert out[1] == "Only in %s: %s" % (archive_ref_path, p1)
         assert out[2] == "Only in %s: %s" % (archive_path, p2)
 
-def test_diff_metadata(test_data, archive_name, monkeypatch):
+@pytest.mark.parametrize("abspath", [False, True])
+def test_diff_metadata(test_data, request, monkeypatch, abspath):
     """Diff two archives having one file's file system metadata modified.
     This difference should be ignored by default.
     """
     monkeypatch.chdir(str(test_data))
-    p = Path("base", "rnd.dat")
+    if abspath:
+        archive_ref_path = Path("archive-abs.tar")
+        base_dir = test_data / "base"
+    else:
+        archive_ref_path = Path("archive-rel.tar")
+        base_dir = Path("base")
+    p = base_dir / "rnd.dat"
     p.chmod(0o0444)
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
-    Archive().create(archive_path, "bz2", [Path("base")])
+    archive_path = archive_name(request, abspath)
+    Archive().create(archive_path, "bz2", [base_dir])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
@@ -184,15 +234,18 @@ def test_diff_metadata(test_data, archive_name, monkeypatch):
         assert out[0] == ("File system metadata for %s:%s and %s:%s differ"
                           % (archive_ref_path, p, archive_path, p))
 
-def test_diff_basedir_equal(test_data, archive_name, monkeypatch):
-    """Diff two archives with different base directories having equal content.
+def test_diff_basedir_equal(test_data, request, monkeypatch):
+    """Diff two archives with different base directories having equal
+    content.
+
+    This test makes only sense for archives with relative path names.
     """
     monkeypatch.chdir(str(test_data))
     newbase = Path("newbase")
     shutil.rmtree(str(newbase), ignore_errors=True)
     Path("base").rename(newbase)
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
+    archive_ref_path = Path("archive-rel.tar")
+    archive_path = archive_name(request, False)
     Archive().create(archive_path, "bz2", [newbase])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
@@ -200,20 +253,22 @@ def test_diff_basedir_equal(test_data, archive_name, monkeypatch):
         f.seek(0)
         assert get_output(f) == []
 
-def test_diff_basedir_mod_file(test_data, archive_name, monkeypatch):
+def test_diff_basedir_mod_file(test_data, request, monkeypatch):
     """Diff two archives with different base directories having one file's
     content modified.
+
+    This test makes only sense for archives with relative path names.
     """
     monkeypatch.chdir(str(test_data))
     base = Path("base")
     newbase = Path("newbase")
     shutil.rmtree(str(newbase), ignore_errors=True)
     base.rename(newbase)
+    archive_ref_path = Path("archive-rel.tar")
     p = base / "rnd.dat"
     pn = newbase / "rnd.dat"
     shutil.copy(str(gettestdata("rnd2.dat")), str(pn))
-    archive_ref_path = Path("archive.tar")
-    archive_path = Path(archive_name + ".bz2")
+    archive_path = archive_name(request, False)
     Archive().create(archive_path, "bz2", [newbase])
     with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]

--- a/tests/test_04_cli_error.py
+++ b/tests/test_04_cli_error.py
@@ -46,9 +46,7 @@ def test_cli_missing_command(test_dir, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = []
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")
@@ -62,9 +60,7 @@ def test_cli_bogus_command(test_dir, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["bogus_cmd"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")
@@ -78,9 +74,7 @@ def test_cli_create_bogus_compression(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", "--compression=bogus_comp", archive_name, "base"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")
@@ -96,9 +90,7 @@ def test_cli_ls_bogus_format(test_dir, archive_name, monkeypatch):
     callscript("archive-tool.py", args)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["ls", "--format=bogus_fmt", archive_name]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")
@@ -112,9 +104,7 @@ def test_cli_create_normalized_path(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", archive_name, "base/empty/.."]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 1
+        callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "invalid path base/empty/..: must be normalized" in line
@@ -123,9 +113,7 @@ def test_cli_create_rel_start_basedir(test_dir, archive_name, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", "--basedir=base/data", archive_name, "base/msg.txt"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 1
+        callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "'base/msg.txt' does not start with 'base/data'" in line
@@ -134,9 +122,7 @@ def test_cli_ls_archive_not_found(test_dir, monkeypatch):
     monkeypatch.chdir(str(test_dir))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["ls", "bogus.tar"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 1
+        callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "No such file or directory: 'bogus.tar'" in line
@@ -147,9 +133,7 @@ def test_cli_ls_checksum_invalid_hash(test_dir, archive_name, monkeypatch):
     callscript("archive-tool.py", args)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["ls", "--format=checksum", "--checksum=bogus", archive_name]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 1
+        callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "'bogus' hashes not available" in line
@@ -160,9 +144,7 @@ def test_cli_info_missing_entry(test_dir, archive_name, monkeypatch):
     callscript("archive-tool.py", args)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["info", archive_name, "base/data/not-present"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 1
+        callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "base/data/not-present: not found in archive" in line
@@ -173,9 +155,7 @@ def test_cli_integrity_no_manifest(test_dir, archive_name, monkeypatch):
         tarf.add("base", recursive=True)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["ls", archive_name]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 3
+        callscript("archive-tool.py", args, returncode=3, stderr=f)
         f.seek(0)
         line = f.readline()
         assert ".manifest.yaml not found" in line
@@ -201,9 +181,7 @@ def test_cli_integrity_missing_file(test_dir, archive_name, monkeypatch):
         tarf.add("base")
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["verify", archive_name]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 3
+        callscript("archive-tool.py", args, returncode=3, stderr=f)
         f.seek(0)
         line = f.readline()
         assert "%s:%s: missing" % (archive_name, missing) in line
@@ -214,9 +192,7 @@ def test_cli_check_missing_files(test_dir, archive_name, monkeypatch):
     callscript("archive-tool.py", args)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", archive_name]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")
@@ -232,9 +208,7 @@ def test_cli_check_stdin_and_files(test_dir, archive_name, monkeypatch):
     callscript("archive-tool.py", args)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--stdin", archive_name, "base"]
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            callscript("archive-tool.py", args, stderr=f)
-        assert exc_info.value.returncode == 2
+        callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
         line = f.readline()
         assert line.startswith("usage: archive-tool.py ")


### PR DESCRIPTION
This adds the `archive-tool diff` subcommand and closes #38.

Still to do:
- [x] add tests
- [x] consider to add an option to skip the content if a directory is only in one of the archives.
- [x] consider to add an option to also report differences in file system metadata.
- [x] consider also the case of archives having entries with absolute path.