### PR TITLE
Add an Archive.extract() method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@ History of changes to archive-tools
 ===================================
 
 0.4 (not yet released)
-    Bug fixes and minor changes
+    New features
+      + #41: Add a :meth:`Archive.extract` method.
       + Add a :meth:`Manifest.sort` method.
 
 0.3 (2019-08-06)


### PR DESCRIPTION
Add a method `extract()` to `class Archive` that extracts the content into a target directory.

Still to do:
- [x] Add tests

Note: for the moment, there is no corresponding subcommand in the command line interface, because it is largely redundant to extracting the archive using the `tar` command.