### PR TITLE
Implement setting tags the manifest

### DIFF
--- a/archive/archive.py
+++ b/archive/archive.py
@@ -61,7 +61,7 @@ class Archive:
 
     def create(self, path, compression, paths, 
                basedir=None, workdir=None, excludes=None, 
-               dedup=DedupMode.LINK):
+               dedup=DedupMode.LINK, tags=None):
         if sys.version_info < (3, 5):
             # The 'x' (exclusive creation) mode was added to tarfile
             # in Python 3.5.
@@ -71,15 +71,15 @@ class Archive:
         if workdir:
             with tmp_chdir(workdir):
                 self._create(workdir / path, mode, paths, 
-                             basedir, excludes, dedup)
+                             basedir, excludes, dedup, tags)
         else:
-            self._create(path, mode, paths, basedir, excludes, dedup)
+            self._create(path, mode, paths, basedir, excludes, dedup, tags)
         return self
 
-    def _create(self, path, mode, paths, basedir, excludes, dedup):
+    def _create(self, path, mode, paths, basedir, excludes, dedup, tags):
         self.path = path
         self._check_paths(paths, basedir, excludes)
-        self.manifest = Manifest(paths=paths, excludes=excludes)
+        self.manifest = Manifest(paths=paths, excludes=excludes, tags=tags)
         self.manifest.add_metadata(self.basedir / ".manifest.yaml")
         for md in self._metadata:
             md.set_path(self.basedir)

--- a/archive/cli/create.py
+++ b/archive/cli/create.py
@@ -22,13 +22,16 @@ def create(args):
             args.compression = 'gz'
     if args.compression == 'none':
         args.compression = ''
-    archive = Archive().create(args.archive, args.compression, args.files, 
-                               basedir=args.basedir, excludes=args.exclude, 
-                               dedup=DedupMode(args.deduplicate))
+    archive = Archive().create(args.archive, args.compression, args.files,
+                               basedir=args.basedir, excludes=args.exclude,
+                               dedup=DedupMode(args.deduplicate),
+                               tags=args.tag)
     return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('create', help="create the archive")
+    parser.add_argument('--tag', action='append',
+                        help=("user defined tags to mark the archive"))
     parser.add_argument('--compression',
                         choices=['none', 'gz', 'bz2', 'xz'],
                         help=("compression mode"))

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -144,7 +144,7 @@ class Manifest(Sequence):
 
     Version = "1.1"
 
-    def __init__(self, fileobj=None, paths=None, excludes=None):
+    def __init__(self, fileobj=None, paths=None, excludes=None, tags=None):
         if fileobj is not None:
             docs = yaml.safe_load_all(fileobj)
             self.head = next(docs)
@@ -159,6 +159,8 @@ class Manifest(Sequence):
                 "Metadata": [],
                 "Version": self.Version,
             }
+            if tags is not None:
+                self.head["Tags"] = tags
             fileinfos = FileInfo.iterpaths(paths, set(excludes or ()))
             self.fileinfos = sorted(fileinfos, key=lambda fi: fi.path)
         else:
@@ -185,6 +187,10 @@ class Manifest(Sequence):
     @property
     def metadata(self):
         return tuple(self.head["Metadata"])
+
+    @property
+    def tags(self):
+        return tuple(self.head.get("Tags", ()))
 
     def add_metadata(self, path):
         self.head["Metadata"].append(str(path))

--- a/tests/test_01_manifest.py
+++ b/tests/test_01_manifest.py
@@ -38,6 +38,7 @@ def test_manifest_from_paths(test_dir, monkeypatch):
     assert manifest.version == Manifest.Version
     assert isinstance(manifest.date, datetime.datetime)
     assert manifest.checksums == tuple(FileInfo.Checksums)
+    assert manifest.tags == ()
     check_manifest(manifest, testdata)
 
 
@@ -53,6 +54,7 @@ def test_manifest_from_fileobj():
     assert manifest.version == "1.1"
     assert isinstance(manifest.date, datetime.datetime)
     assert manifest.checksums == ("sha256",)
+    assert manifest.tags == ()
     check_manifest(manifest, testdata)
 
 
@@ -144,3 +146,17 @@ def test_mnifest_sort(test_dir, monkeypatch):
         if prev is not None:
             assert fi.path >= prev.path
         prev = fi
+
+
+@pytest.mark.parametrize(("tags", "expected"), [
+    (None, ()),
+    ([], ()),
+    (["a"], ("a",)),
+    (["a", "b"], ("a", "b")),
+])
+def test_manifest_tags(test_dir, monkeypatch, tags, expected):
+    """Set tags in a manifest reading the files in test_dir.
+    """
+    monkeypatch.chdir(str(test_dir))
+    manifest = Manifest(paths=[Path("base")], tags=tags)
+    assert manifest.tags == expected

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -98,3 +98,21 @@ def test_create_add_symlink(test_dir, monkeypatch):
     with Archive().open(archive_path) as archive:
         check_manifest(archive.manifest, data)
         archive.verify()
+
+count = 0
+@pytest.mark.parametrize(("tags", "expected"), [
+    (None, ()),
+    ([], ()),
+    (["a"], ("a",)),
+    (["a", "b"], ("a", "b")),
+])
+def test_create_tags(test_dir, monkeypatch, tags, expected):
+    """Test setting tags.
+    """
+    global count
+    count += 1
+    monkeypatch.chdir(str(test_dir))
+    archive_path = "archive-tags-%d.tar" % count
+    Archive().create(archive_path, "", [Path("base")], tags=tags)
+    with Archive().open(archive_path) as archive:
+        assert archive.manifest.tags == expected

--- a/tests/test_04_cli_create_misc.py
+++ b/tests/test_04_cli_create_misc.py
@@ -1,0 +1,47 @@
+"""Misc issues around using the command line tool to create an archive.
+"""
+
+from pathlib import Path
+import pytest
+from archive import Archive
+from conftest import *
+
+
+# Setup a directory with some test data to be put into an archive.
+# Make sure that we have all kind of different things in there.
+testdata = [
+    DataDir(Path("base"), 0o755, mtime=1565100853),
+    DataDir(Path("base", "data"), 0o750, mtime=1555271302),
+    DataDir(Path("base", "empty"), 0o755, mtime=1547911753),
+    DataFile(Path("base", "msg.txt"), 0o644, mtime=1547911753),
+    DataFile(Path("base", "data", "rnd.dat"), 0o600, mtime=1563112510),
+    DataSymLink(Path("base", "s.dat"), Path("data", "rnd.dat"),
+                mtime=1565100853),
+]
+
+@pytest.fixture(scope="module")
+def test_dir(tmpdir):
+    setup_testdata(tmpdir, testdata)
+    return tmpdir
+
+count = 0
+@pytest.mark.parametrize(("tags", "expected"), [
+    ([], ()),
+    (["a"], ("a",)),
+    (["a", "b"], ("a", "b")),
+])
+def test_cli_create_tags(test_dir, monkeypatch, tags, expected):
+    """Set tags using the --tags argument.
+    """
+    global count
+    count += 1
+    monkeypatch.chdir(str(test_dir))
+    archive_path = "archive-tags-%d.tar" % count
+    args = ["create"]
+    for t in tags:
+        args += ("--tag", t)
+    args += (archive_path, "base")
+    callscript("archive-tool.py", args)
+    with Archive().open(archive_path) as archive:
+        assert archive.manifest.tags == expected
+        check_manifest(archive.manifest, testdata)


### PR DESCRIPTION
Implement setting user defined tags in the manifest header. Close #40 

Rather the setting a single `Domain` field as suggested in #40, this sets a list of tags. The manifest version is not bumped, because the `Tags` field is optional and fully compatible with earlier versions. The whole feature is experimental and may be changed in the future.