### PR TITLE
Review Archive.create()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Changelog
 New features
 ------------
 
++ `#54`_: Add a command line flags `--directory <dir>` to
+  `archive-tool create`.  The script will change into this directory
+  prior creating the archive if provided.
+
++ `#54`_: Add a new keyword argument `fileinfos` that
+  :class:`Manifest` and :meth:`Archive.create` accept.
+
 + `#50`_, `#51`_: Add a header with some metadata to the index in a
   mail archive created by :class:`MailArchive`.
 
@@ -20,11 +27,17 @@ Incompatible changes
 Bug fixes and minor changes
 ---------------------------
 
++ `#53`_, `#54`_: Spurious :exc:`FileNotFoundError` from
+  :meth:`Archive.create` when passing a relative path as `workdir`
+  argument.
+
 + `#48`_: Review and standardize some error messages.
 
 .. _#48: https://github.com/RKrahl/archive-tools/pull/48
 .. _#50: https://github.com/RKrahl/archive-tools/issues/50
 .. _#51: https://github.com/RKrahl/archive-tools/pull/51
+.. _#53: https://github.com/RKrahl/archive-tools/issues/53
+.. _#54: https://github.com/RKrahl/archive-tools/pull/54
 
 
 0.5.1 (2020-12-12)

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -115,8 +115,7 @@ class Archive:
 
     def _check_paths(self, paths, basedir, excludes):
         """Check the paths to be added to an archive for several error
-        conditions.  Accept a list of either strings or path-like
-        objects.  Convert them to a list of Path objects.  Also sets
+        conditions.  Accept a list of path-like objects.  Also sets
         self.basedir.
         """
         if not paths:

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -124,12 +124,12 @@ class Archive:
         """
         if not paths:
             raise ArchiveCreateError("refusing to create an empty archive")
+        abspath = paths[0].is_absolute()
         if not basedir:
-            p = paths[0]
-            if p.is_absolute():
+            if abspath:
                 self.basedir = Path(self.path.name.split('.')[0])
             else:
-                self.basedir = Path(p.parts[0])
+                self.basedir = Path(paths[0].parts[0])
         else:
             self.basedir = basedir
         if self.basedir.is_absolute():
@@ -140,17 +140,13 @@ class Archive:
         # The same rules for paths also apply to excludes, if
         # provided.  So we may just iterate over the chain of both
         # lists.
-        abspath = None
         for p in itertools.chain(paths, excludes or ()):
             if not _is_normalized(p):
                 raise ArchiveCreateError("invalid path '%s': "
                                          "must be normalized" % p)
-            if abspath is None:
-                abspath = p.is_absolute()
-            else:
-                if abspath != p.is_absolute():
-                    raise ArchiveCreateError("mixing of absolute and relative "
-                                             "paths is not allowed")
+            if abspath != p.is_absolute():
+                raise ArchiveCreateError("mixing of absolute and relative "
+                                         "paths is not allowed")
             if not p.is_absolute():
                 try:
                     # This will raise ValueError if p does not start

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -80,7 +80,10 @@ class Archive:
                 if not isinstance(fileinfos, Sequence):
                     fileinfos = list(fileinfos)
                 self._check_paths([fi.path for fi in fileinfos], basedir)
-                self.manifest = Manifest(fileinfos=fileinfos, tags=tags)
+                try:
+                    self.manifest = Manifest(fileinfos=fileinfos, tags=tags)
+                except ValueError as e:
+                    raise ArchiveCreateError("invalid fileinfos: %s" % e)
             else:
                 self._check_paths(paths, basedir, excludes)
                 self.manifest = Manifest(paths=paths, excludes=excludes,

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -70,7 +70,7 @@ class Archive:
             mode = 'x:' + compression
         if workdir:
             with tmp_chdir(workdir):
-                self._create(workdir / path, mode, paths, 
+                self._create(path, mode, paths, 
                              basedir, excludes, dedup, tags)
         else:
             self._create(path, mode, paths, basedir, excludes, dedup, tags)

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -3,6 +3,7 @@
 
 from enum import Enum
 import itertools
+import os
 from pathlib import Path
 import stat
 import sys
@@ -10,7 +11,7 @@ import tarfile
 import tempfile
 from archive.manifest import Manifest
 from archive.exception import *
-from archive.tools import tmp_chdir, checksum
+from archive.tools import checksum
 
 def _is_normalized(p):
     """Check if the path is normalized.
@@ -68,12 +69,15 @@ class Archive:
             mode = 'w:' + compression
         else:
             mode = 'x:' + compression
-        if workdir:
-            with tmp_chdir(workdir):
-                self._create(path, mode, paths, 
-                             basedir, excludes, dedup, tags)
-        else:
+        save_wd = None
+        try:
+            if workdir:
+                save_wd = os.getcwd()
+                os.chdir(str(workdir))
             self._create(path, mode, paths, basedir, excludes, dedup, tags)
+        finally:
+            if save_wd:
+                os.chdir(save_wd)
         return self
 
     def _create(self, path, mode, paths, basedir, excludes, dedup, tags):

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -74,20 +74,20 @@ class Archive:
             if workdir:
                 save_wd = os.getcwd()
                 os.chdir(str(workdir))
-            self._create(path, mode, paths, basedir, excludes, dedup, tags)
+            self.path = path
+            self._check_paths(paths, basedir, excludes)
+            self.manifest = Manifest(paths=paths, excludes=excludes, tags=tags)
+            self.manifest.add_metadata(self.basedir / ".manifest.yaml")
+            for md in self._metadata:
+                md.set_path(self.basedir)
+                self.manifest.add_metadata(md.path)
+            self._create(mode, dedup)
         finally:
             if save_wd:
                 os.chdir(save_wd)
         return self
 
-    def _create(self, path, mode, paths, basedir, excludes, dedup, tags):
-        self.path = path
-        self._check_paths(paths, basedir, excludes)
-        self.manifest = Manifest(paths=paths, excludes=excludes, tags=tags)
-        self.manifest.add_metadata(self.basedir / ".manifest.yaml")
-        for md in self._metadata:
-            md.set_path(self.basedir)
-            self.manifest.add_metadata(md.path)
+    def _create(self, mode, dedup):
         with tarfile.open(str(self.path), mode) as tarf:
             with tempfile.TemporaryFile() as tmpf:
                 self.manifest.write(tmpf)

--- a/archive/cli/create.py
+++ b/archive/cli/create.py
@@ -23,13 +23,16 @@ def create(args):
     if args.compression == 'none':
         args.compression = ''
     archive = Archive().create(args.archive, args.compression, args.files,
-                               basedir=args.basedir, excludes=args.exclude,
+                               basedir=args.basedir, workdir=args.directory,
+                               excludes=args.exclude,
                                dedup=DedupMode(args.deduplicate),
                                tags=args.tag)
     return 0
 
 def add_parser(subparsers):
     parser = subparsers.add_parser('create', help="create the archive")
+    parser.add_argument('--directory', type=Path,
+                        help=("change directory prior creating the archive"))
     parser.add_argument('--tag', action='append',
                         help=("user defined tags to mark the archive"))
     parser.add_argument('--compression',

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -163,8 +163,15 @@ class Manifest(Sequence):
             if tags is not None:
                 self.head["Tags"] = tags
             if fileinfos is None:
-                fileinfos = FileInfo.iterpaths(paths, set(excludes or ()))
-            self.fileinfos = list(fileinfos)
+                fileinfos = list(FileInfo.iterpaths(paths, set(excludes or ())))
+            else:
+                fileinfos = list(fileinfos)
+                cs = set(FileInfo.Checksums)
+                for fi in fileinfos:
+                    if fi.is_file() and not cs.issubset(fi.checksum.keys()):
+                        raise ValueError("Missing checksum on item %s"
+                                         % fi.path)
+            self.fileinfos = fileinfos
             self.sort()
         else:
             raise TypeError("Either fileobj or paths or fileinfos "

--- a/tests/test_01_manifest.py
+++ b/tests/test_01_manifest.py
@@ -26,22 +26,6 @@ def test_dir(tmpdir):
     return tmpdir
 
 
-def test_manifest_from_paths(test_dir, monkeypatch):
-    """Create a manifest reading the files in test_dir.
-    """
-    monkeypatch.chdir(str(test_dir))
-    manifest = Manifest(paths=[Path("base")])
-    head = manifest.head
-    assert set(head.keys()) == {
-        "Checksums", "Date", "Generator", "Metadata", "Version"
-    }
-    assert manifest.version == Manifest.Version
-    assert isinstance(manifest.date, datetime.datetime)
-    assert manifest.checksums == tuple(FileInfo.Checksums)
-    assert manifest.tags == ()
-    check_manifest(manifest, testdata)
-
-
 def test_manifest_from_fileobj():
     """Read a manifest from a YAML file.
     """
@@ -54,6 +38,22 @@ def test_manifest_from_fileobj():
     assert manifest.version == "1.1"
     assert isinstance(manifest.date, datetime.datetime)
     assert manifest.checksums == ("sha256",)
+    assert manifest.tags == ()
+    check_manifest(manifest, testdata)
+
+
+def test_manifest_from_paths(test_dir, monkeypatch):
+    """Create a manifest reading the files in test_dir.
+    """
+    monkeypatch.chdir(str(test_dir))
+    manifest = Manifest(paths=[Path("base")])
+    head = manifest.head
+    assert set(head.keys()) == {
+        "Checksums", "Date", "Generator", "Metadata", "Version"
+    }
+    assert manifest.version == Manifest.Version
+    assert isinstance(manifest.date, datetime.datetime)
+    assert manifest.checksums == tuple(FileInfo.Checksums)
     assert manifest.tags == ()
     check_manifest(manifest, testdata)
 
@@ -115,7 +115,25 @@ def test_manifest_exclude_explicit_include(test_dir, monkeypatch):
     data = sub_testdata(testdata, excludes[0], paths[1])
     check_manifest(manifest, data)
 
-def test_mnifest_sort(test_dir, monkeypatch):
+
+def test_manifest_from_fileinfos(test_dir, monkeypatch):
+    """Create a manifest providing an iterable of fileinfos.
+    """
+    monkeypatch.chdir(str(test_dir))
+    fileinfos = FileInfo.iterpaths([Path("base")], set())
+    manifest = Manifest(fileinfos=fileinfos)
+    head = manifest.head
+    assert set(head.keys()) == {
+        "Checksums", "Date", "Generator", "Metadata", "Version"
+    }
+    assert manifest.version == Manifest.Version
+    assert isinstance(manifest.date, datetime.datetime)
+    assert manifest.checksums == tuple(FileInfo.Checksums)
+    assert manifest.tags == ()
+    check_manifest(manifest, testdata)
+
+
+def test_manifest_sort(test_dir, monkeypatch):
     """Test the Manifest.sort() method.
     """
     monkeypatch.chdir(str(test_dir))

--- a/tests/test_03_create_fileinfos.py
+++ b/tests/test_03_create_fileinfos.py
@@ -1,0 +1,77 @@
+"""Test creating an archive from an iterable of FileInfo objects.
+"""
+
+from pathlib import Path
+import pytest
+from archive import Archive
+from archive.manifest import FileInfo, Manifest
+from conftest import *
+
+
+# Setup a directory with some test data to be put into an archive.
+# Make sure that we have all kind of different things in there.
+testdata = [
+    DataDir(Path("base"), 0o755, mtime=1565100853),
+    DataDir(Path("base", "data"), 0o750, mtime=1555271302),
+    DataDir(Path("base", "empty"), 0o755, mtime=1547911753),
+    DataFile(Path("base", "msg.txt"), 0o644, mtime=1547911753),
+    DataFile(Path("base", "data", "rnd.dat"), 0o600, mtime=1563112510),
+    DataSymLink(Path("base", "s.dat"), Path("data", "rnd.dat"),
+                mtime=1565100853),
+]
+sha256sum = "sha256sum"
+
+@pytest.fixture(scope="module")
+def test_dir(tmpdir):
+    setup_testdata(tmpdir, testdata)
+    return tmpdir
+
+
+def test_create_fileinfos_list(test_dir, monkeypatch):
+    """Create the archive from a list of FileInfo objects.
+    """
+    monkeypatch.chdir(str(test_dir))
+    fileinfos = list(FileInfo.iterpaths([Path("base")], set()))
+    archive_path = Path("archive-fi-list.tar")
+    Archive().create(archive_path, "", fileinfos=fileinfos)
+    with Archive().open(archive_path) as archive:
+        check_manifest(archive.manifest, testdata)
+        archive.verify()
+
+def test_create_fileinfos_generator(test_dir, monkeypatch):
+    """Create the archive from FileInfo.iterpaths() which returns a generator.
+    """
+    monkeypatch.chdir(str(test_dir))
+    fileinfos = FileInfo.iterpaths([Path("base")], set())
+    archive_path = Path("archive-fi-generator.tar")
+    Archive().create(archive_path, "", fileinfos=fileinfos)
+    with Archive().open(archive_path) as archive:
+        check_manifest(archive.manifest, testdata)
+        archive.verify()
+
+def test_create_fileinfos_manifest(test_dir, monkeypatch):
+    """Create the archive from a Manifest.
+    A Manifest is an iterable of FileInfo objects.
+    """
+    monkeypatch.chdir(str(test_dir))
+    manifest = Manifest(paths=[Path("base")])
+    archive_path = Path("archive-fi-manifest.tar")
+    Archive().create(archive_path, "", fileinfos=manifest)
+    with Archive().open(archive_path) as archive:
+        check_manifest(archive.manifest, testdata)
+        archive.verify()
+
+def test_create_fileinfos_subset(test_dir, monkeypatch):
+    """Do not include the content of a directory.
+    This test verifies that creating an archive from fileinfos does
+    not implicitly descend subdirectories.
+    """
+    monkeypatch.chdir(str(test_dir))
+    excludes = [Path("base", "data", "rnd.dat")]
+    fileinfos = FileInfo.iterpaths([Path("base")], set(excludes))
+    data = sub_testdata(testdata, excludes[0])
+    archive_path = Path("archive-fi-subset.tar")
+    Archive().create(archive_path, "", fileinfos=fileinfos)
+    with Archive().open(archive_path) as archive:
+        check_manifest(archive.manifest, data)
+        archive.verify()

--- a/tests/test_03_create_workdir.py
+++ b/tests/test_03_create_workdir.py
@@ -1,0 +1,41 @@
+"""Tests passing the workdir keyword argument to Archive.create().
+"""
+
+from pathlib import Path
+import pytest
+from archive import Archive
+from conftest import *
+
+
+testdata = [
+    DataDir(Path("base"), 0o755),
+    DataDir(Path("base", "data"), 0o755),
+    DataFile(Path("base", "data", "rnd.dat"), 0o644),
+]
+
+@pytest.fixture(scope="module")
+def test_dir(tmpdir):
+    setup_testdata(tmpdir / "work", testdata)
+    return tmpdir
+
+
+@pytest.mark.parametrize("abs_wd", [
+    True,
+    pytest.param(False, marks=pytest.mark.xfail(raises=FileNotFoundError,
+                                                reason="Issue #53"))
+], ids=absflag)
+def test_create_workdir(test_dir, monkeypatch, abs_wd):
+    """Pass an absolute or relative workdir to Archive.create().
+    (Issue #53)
+    """
+    monkeypatch.chdir(str(test_dir))
+    if abs_wd:
+        workdir = test_dir / "work"
+    else:
+        workdir = Path("work")
+    archive_path = Path(archive_name(tags=[absflag(abs_wd)]))
+    Archive().create(archive_path, "", [Path("base")], workdir=workdir)
+    with Archive().open(workdir / archive_path) as archive:
+        assert archive.basedir == Path("base")
+        check_manifest(archive.manifest, testdata)
+        archive.verify()

--- a/tests/test_03_create_workdir.py
+++ b/tests/test_03_create_workdir.py
@@ -19,11 +19,7 @@ def test_dir(tmpdir):
     return tmpdir
 
 
-@pytest.mark.parametrize("abs_wd", [
-    True,
-    pytest.param(False, marks=pytest.mark.xfail(raises=FileNotFoundError,
-                                                reason="Issue #53"))
-], ids=absflag)
+@pytest.mark.parametrize("abs_wd", [ True, False ], ids=absflag)
 def test_create_workdir(test_dir, monkeypatch, abs_wd):
     """Pass an absolute or relative workdir to Archive.create().
     (Issue #53)

--- a/tests/test_04_cli_create_misc.py
+++ b/tests/test_04_cli_create_misc.py
@@ -42,3 +42,12 @@ def test_cli_create_tags(test_dir, monkeypatch, tags, expected):
     with Archive().open(archive_path) as archive:
         assert archive.manifest.tags == expected
         check_manifest(archive.manifest, testdata)
+
+def test_cli_create_directory(test_dir):
+    """Change the working directory using the --directory argument.
+    """
+    archive_path = archive_name(tags=["dir"])
+    args = ["create", "--directory", str(test_dir), archive_path, "base"]
+    callscript("archive-tool.py", args)
+    with Archive().open(test_dir / archive_path) as archive:
+        check_manifest(archive.manifest, testdata)


### PR DESCRIPTION
Various changes in the `Archive.create()` method:

- Fix #53.

- Add a command line argument `--directory` to `archive-tool create`. This makes the working directory implemented in #20 accessible in the command line script.

- Some refactoring in `Archive.create()`.

- Add a new keyword argument `fileinfos` that `Manifest()` and `Archive.create()` accept. If provided, it must be an iterable of `FileInfo` objects and will override the `paths` and `excludes` arguments respectively, e.g. the fileinfo objects will be used to define the content of the manifest and the archive respectively.

The latter bullet is supposed to make the implementation of incremental archives easier and thus to be an ingredient for the implementation of #52.