### PR TITLE
Weaken the condition that basedir must be a directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Bug fixes and minor changes
 + `#57`_: Do not take the paths relative to the base directory in the
   `archive-tool diff` command.
 
++ `#58`_: Weaken the condition introduced in `#9`_ that basedir must
+  be a directory.
+
 + `#53`_, `#54`_: Spurious :exc:`FileNotFoundError` from
   :meth:`Archive.create` when passing a relative path as `workdir`
   argument.
@@ -51,6 +54,7 @@ Bug fixes and minor changes
 .. _#55: https://github.com/RKrahl/archive-tools/issues/55
 .. _#56: https://github.com/RKrahl/archive-tools/issues/56
 .. _#57: https://github.com/RKrahl/archive-tools/pull/57
+.. _#58: https://github.com/RKrahl/archive-tools/pull/58
 
 
 0.5.1 (2020-12-12)
@@ -221,3 +225,5 @@ Bug fixes and minor changes
 ~~~~~~~~~~~~~~~~
 
 + Initial release.
+
+.. _#9: https://github.com/RKrahl/archive-tools/issues/9

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -92,6 +92,10 @@ class Archive:
                 self._check_paths(paths, basedir, excludes)
                 self.manifest = Manifest(paths=paths, excludes=excludes,
                                          tags=tags)
+            bd_fi = self.manifest.find(self.basedir)
+            if bd_fi and not bd_fi.is_dir():
+                raise ArchiveCreateError("base directory %s must "
+                                         "be a directory" % self.basedir)
             self.manifest.add_metadata(self.basedir / ".manifest.yaml")
             for md in self._metadata:
                 md.set_path(self.basedir)
@@ -172,9 +176,6 @@ class Archive:
                     raise ArchiveCreateError("invalid path '%s': must be a "
                                              "subpath of base directory %s"
                                              % (p, self.basedir))
-        if not abspath:
-            if self.basedir.is_symlink() or not self.basedir.is_dir():
-                raise ArchiveCreateError("basedir must be a directory")
 
     def _add_metadata_files(self, tarf):
         """Add the metadata files to the tar file.


### PR DESCRIPTION
In #9 a check has been introduced for archives with relative paths that the base directory must exist and be a directory.

This change weakens that condition somewhat: if an item is added to the archive having the base directory as path, that item must be a directory item. It is not checked any more that the base directory exists in the file system.

Implicitly this is still checked in the current `Archive` class while creating the archive, because all items in an archive with relative paths must have a path relative to the base directory and these items are read from the file system, so the base directory as a parent must still exist. But this changes allows to create derived variants of the `Archive` class that do not read the items from the file system.