### PR TITLE
Make Archive.path absolute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Incompatible changes
 Bug fixes and minor changes
 ---------------------------
 
++ `#59`_: Change :attr:`Archive.path` to the absolute path of the
+  archive.
+
 + `#57`_: Do not take the paths relative to the base directory in the
   `archive-tool diff` command.
 
@@ -57,6 +60,7 @@ Bug fixes and minor changes
 .. _#56: https://github.com/RKrahl/archive-tools/issues/56
 .. _#57: https://github.com/RKrahl/archive-tools/pull/57
 .. _#58: https://github.com/RKrahl/archive-tools/pull/58
+.. _#59: https://github.com/RKrahl/archive-tools/pull/59
 .. _#60: https://github.com/RKrahl/archive-tools/pull/60
 
 

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -77,7 +77,7 @@ class Archive:
             if workdir:
                 save_wd = os.getcwd()
                 os.chdir(str(workdir))
-            self.path = path
+            self.path = path.resolve()
             self._dedup = dedup
             self._dupindex = {}
             if fileinfos is not None:
@@ -221,11 +221,11 @@ class Archive:
         self._metadata.insert(0, md)
 
     def open(self, path):
-        self.path = path
         try:
-            self._file = tarfile.open(str(self.path), 'r')
+            self._file = tarfile.open(str(path), 'r')
         except OSError as e:
             raise ArchiveReadError(str(e))
+        self.path = path.resolve()
         md = self.get_metadata(".manifest.yaml")
         self.basedir = md.path.parent
         self.manifest = Manifest(fileobj=md.fileobj)

--- a/archive/cli/diff.py
+++ b/archive/cli/diff.py
@@ -42,26 +42,26 @@ def diff(args):
     status = 0
     for diff_stat, fi1, fi2 in diff:
         if diff_stat == DiffStatus.MISSING_A:
-            print("Only in %s: %s" % (archive2.path, fi2.path))
+            print("Only in %s: %s" % (args.archive2, fi2.path))
             status = max(status, 102)
         elif diff_stat == DiffStatus.MISSING_B:
-            print("Only in %s: %s" % (archive1.path, fi1.path))
+            print("Only in %s: %s" % (args.archive1, fi1.path))
             status = max(status, 102)
         elif diff_stat == DiffStatus.TYPE:
             print("Entries %s:%s and %s:%s have different type"
-                  % (archive1.path, fi1.path, archive2.path, fi2.path))
+                  % (args.archive1, fi1.path, args.archive2, fi2.path))
             status = max(status, 102)
         elif diff_stat == DiffStatus.SYMLNK_TARGET:
             print("Symbol links %s:%s and %s:%s have different target"
-                  % (archive1.path, fi1.path, archive2.path, fi2.path))
+                  % (args.archive1, fi1.path, args.archive2, fi2.path))
             status = max(status, 101)
         elif diff_stat == DiffStatus.CONTENT:
             print("Files %s:%s and %s:%s differ"
-                  % (archive1.path, fi1.path, archive2.path, fi2.path))
+                  % (args.archive1, fi1.path, args.archive2, fi2.path))
             status = max(status, 101)
         elif diff_stat == DiffStatus.META and args.report_meta:
             print("File system metadata for %s:%s and %s:%s differ"
-                  % (archive1.path, fi1.path, archive2.path, fi2.path))
+                  % (args.archive1, fi1.path, args.archive2, fi2.path))
             status = max(status, 100)
     return status
 

--- a/tests/test_03_create_filetype.py
+++ b/tests/test_03_create_filetype.py
@@ -54,13 +54,13 @@ def test_create_invalid_file_socket(test_dir, testname, monkeypatch):
     """Create an archive from a directory containing a socket.
     """
     monkeypatch.chdir(str(test_dir))
-    name = archive_name(tags=[testname])
+    archive_path = Path(archive_name(tags=[testname]))
     p = Path("base")
     fp = p / "socket"
     with tmp_socket(fp):
         with pytest.warns(ArchiveWarning, match="%s: socket ignored" % fp):
-            Archive().create(name, "", [p])
-    with Archive().open(name) as archive:
+            Archive().create(archive_path, "", [p])
+    with Archive().open(archive_path) as archive:
         assert archive.basedir == Path("base")
         check_manifest(archive.manifest, testdata)
         archive.verify()
@@ -69,13 +69,13 @@ def test_create_invalid_file_fifo(test_dir, testname, monkeypatch):
     """Create an archive from a directory containing a FIFO.
     """
     monkeypatch.chdir(str(test_dir))
-    name = archive_name(tags=[testname])
+    archive_path = Path(archive_name(tags=[testname]))
     p = Path("base")
     fp = p / "fifo"
     with tmp_fifo(fp):
         with pytest.warns(ArchiveWarning, match="%s: FIFO ignored" % fp):
-            Archive().create(name, "", [p])
-    with Archive().open(name) as archive:
+            Archive().create(archive_path, "", [p])
+    with Archive().open(archive_path) as archive:
         assert archive.basedir == Path("base")
         check_manifest(archive.manifest, testdata)
         archive.verify()

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -28,7 +28,7 @@ def test_create_default_basedir_rel(test_dir, monkeypatch):
     """Check the default basedir with relative paths.  (Issue #8)
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = "archive-rel.tar"
+    archive_path = Path("archive-rel.tar")
     p = Path("base", "data")
     Archive().create(archive_path, "", [p])
     with Archive().open(archive_path) as archive:
@@ -91,7 +91,7 @@ def test_create_add_symlink(test_dir, monkeypatch):
     """Check adding explicitly adding a symbolic link.  (Issue #37)
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = "archive-symlink.tar"
+    archive_path = Path("archive-symlink.tar")
     paths = [Path("base", "data", "misc"), Path("base", "data", "s.dat")]
     data = [ testdata[i] for i in (1,3,4) ]
     Archive().create(archive_path, "", paths)
@@ -109,7 +109,7 @@ def test_create_tags(test_dir, monkeypatch, tags, expected):
     """Test setting tags.
     """
     monkeypatch.chdir(str(test_dir))
-    archive_path = archive_name(tags=["tags"], counter="create_tags")
+    archive_path = Path(archive_name(tags=["tags"], counter="create_tags"))
     Archive().create(archive_path, "", [Path("base")], tags=tags)
     with Archive().open(archive_path) as archive:
         assert archive.manifest.tags == expected

--- a/tests/test_04_cli.py
+++ b/tests/test_04_cli.py
@@ -54,7 +54,7 @@ def test_cli_create(test_dir, monkeypatch, testcase):
     compression, abspath = testcase
     require_compression(compression)
     monkeypatch.chdir(str(test_dir))
-    archive_path = archive_name(ext=compression, tags=[absflag(abspath)])
+    archive_path = Path(archive_name(ext=compression, tags=[absflag(abspath)]))
     if abspath:
         paths = str(test_dir / "base")
         basedir = "archive"
@@ -64,7 +64,7 @@ def test_cli_create(test_dir, monkeypatch, testcase):
     if compression is None:
         compression = "none"
     args = ["create", "--compression", compression, "--basedir", basedir,
-            archive_path, paths]
+            str(archive_path), paths]
     callscript("archive-tool.py", args)
     with Archive().open(archive_path) as archive:
         assert str(archive.basedir) == basedir

--- a/tests/test_04_cli_create_misc.py
+++ b/tests/test_04_cli_create_misc.py
@@ -39,7 +39,7 @@ def test_cli_create_tags(test_dir, monkeypatch, tags, expected):
         args += ("--tag", t)
     args += (archive_path, "base")
     callscript("archive-tool.py", args)
-    with Archive().open(archive_path) as archive:
+    with Archive().open(Path(archive_path)) as archive:
         assert archive.manifest.tags == expected
         check_manifest(archive.manifest, testdata)
 

--- a/tests/test_04_cli_warn.py
+++ b/tests/test_04_cli_warn.py
@@ -55,7 +55,7 @@ def test_cli_warn_ignore_socket(test_dir, testname, monkeypatch):
             f.seek(0)
             line = f.readline().strip()
             assert line == ("archive-tool.py: %s: socket ignored" % fp)
-    with Archive().open(name) as archive:
+    with Archive().open(Path(name)) as archive:
         assert archive.basedir == basedir
         check_manifest(archive.manifest, testdata)
         archive.verify()


### PR DESCRIPTION
- Resolve the `Archive.path` attribute, e.g. set it to the absolute path of the archive.
- Fix many tests that were still passing a string as `path` argument to `Archive.create()` and `Archive.open()`, despite the fact that this is not supported since 0.3, ref. #36.