### PR TITLE
Drop support for Python 3.4 and 3.5

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,9 +1,6 @@
-PyYAML <=5.2 ; python_version == '3.4'
-PyYAML >=5.3.1 ; python_version == '3.5'
-PyYAML >=5.4 ; python_version > '3.5'
+PyYAML >=5.4
 distutils-pytest
 pytest >=3.6.0
 pytest-dependency >=0.2
 python-dateutil
 setuptools_scm
-typing ; python_version == '3.4'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,16 +6,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.5'
           - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10.0-beta - 3.10.0'
         os: [ubuntu-latest]
-        include:
-          - python-version: '3.4'
-            os: ubuntu-18.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ New features
 Incompatible changes
 --------------------
 
++ `#60`_: Drop support for Python 3.4 and 3.5.
+
 + The `comment` keyword argument to :class:`MailArchive` has been
   dropped, ref. `#51`_.
 
@@ -55,6 +57,7 @@ Bug fixes and minor changes
 .. _#56: https://github.com/RKrahl/archive-tools/issues/56
 .. _#57: https://github.com/RKrahl/archive-tools/pull/57
 .. _#58: https://github.com/RKrahl/archive-tools/pull/58
+.. _#60: https://github.com/RKrahl/archive-tools/pull/60
 
 
 0.5.1 (2020-12-12)

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ System requirements
 
 Python:
 
-+ Python 3.4 or newer.
++ Python 3.6 or newer.
 
 Required library packages:
 

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -66,12 +66,7 @@ class Archive:
     def create(self, path, compression, paths=None, fileinfos=None,
                basedir=None, workdir=None, excludes=None,
                dedup=DedupMode.LINK, tags=None):
-        if sys.version_info < (3, 5):
-            # The 'x' (exclusive creation) mode was added to tarfile
-            # in Python 3.5.
-            mode = 'w:' + compression
-        else:
-            mode = 'x:' + compression
+        mode = 'x:' + compression
         save_wd = None
         try:
             if workdir:

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -102,7 +102,7 @@ class Archive:
         return self
 
     def _create(self, mode):
-        with tarfile.open(str(self.path), mode) as tarf:
+        with tarfile.open(self.path, mode) as tarf:
             with tempfile.TemporaryFile() as tmpf:
                 self.manifest.write(tmpf)
                 tmpf.seek(0)
@@ -218,7 +218,7 @@ class Archive:
     def open(self, path):
         self.path = path
         try:
-            self._file = tarfile.open(str(self.path), 'r')
+            self._file = tarfile.open(self.path, 'r')
         except OSError as e:
             raise ArchiveReadError(str(e))
         md = self.get_metadata(".manifest.yaml")

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -71,7 +71,7 @@ class Archive:
         try:
             if workdir:
                 save_wd = os.getcwd()
-                os.chdir(str(workdir))
+                os.chdir(workdir)
             self.path = path
             self._dedup = dedup
             self._dupindex = {}

--- a/archive/cli/check.py
+++ b/archive/cli/check.py
@@ -47,10 +47,10 @@ def check(args):
             if (args.prefix / fi.path in metadata or 
                 entry and _matches(args.prefix, fi, entry)):
                 if args.present and not fi.is_dir():
-                    print(str(fi.path))
+                    print(fi.path)
             else:
                 if not args.present:
-                    print(str(fi.path))
+                    print(fi.path)
                 if fi.is_dir():
                     skip = True
     return 0

--- a/archive/exception.py
+++ b/archive/exception.py
@@ -48,7 +48,7 @@ class ArchiveInvalidTypeError(ArchiveError):
             tstr = "socket"
         else:
             tstr = "unsuported type %x" % ftype
-        super().__init__("%s: %s" % (str(path), tstr))
+        super().__init__("%s: %s" % (path, tstr))
 
 class ArchiveWarning(Warning):
     pass

--- a/archive/mailarchive.py
+++ b/archive/mailarchive.py
@@ -58,7 +58,7 @@ class MailArchive(Archive):
         with TemporaryDirectory(prefix="mailarchive-") as tmpdir:
             with tmp_chdir(tmpdir), tmp_umask(0o077):
                 basedir = Path(path.name.split('.')[0])
-                maildir = Maildir(str(basedir), create=True)
+                maildir = Maildir(basedir, create=True)
                 self.mailindex = MailIndex(server=server)
                 last_folder = None
                 for folder, msgbytes in mails:

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -129,7 +129,7 @@ class FileInfo:
         if self.type == 'l':
             p = "%s -> %s" % (self.path, self.target)
         else:
-            p = str(self.path)
+            p = self.path
         return "%s  %s  %s  %s  %s" % (m, ug, s, d, p)
 
     @classmethod

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -71,7 +71,7 @@ class FileInfo:
             elif stat.S_ISDIR(fstat.st_mode):
                 pass
             elif stat.S_ISLNK(fstat.st_mode):
-                self.target = Path(os.readlink(str(self.path)))
+                self.target = Path(os.readlink(self.path))
             else:
                 ftype = stat.S_IFMT(fstat.st_mode)
                 raise ArchiveInvalidTypeError(self.path, ftype)

--- a/archive/tools.py
+++ b/archive/tools.py
@@ -25,7 +25,7 @@ class tmp_chdir():
     """
     def __init__(self, dir):
         self.save_dir = None
-        self.dir = str(dir)
+        self.dir = dir
     def __enter__(self):
         self.save_dir = os.getcwd()
         os.chdir(self.dir)

--- a/python-archive-tools.spec
+++ b/python-archive-tools.spec
@@ -10,7 +10,7 @@ License:	Apache-2.0
 Group:		Development/Libraries/Python
 Source:		%{distname}-%{version}.tar.gz
 BuildRequires:	fdupes
-BuildRequires:	python3-base >= 3.4
+BuildRequires:	python3-base >= 3.6
 %if %{with tests}
 BuildRequires:	python3-PyYAML
 BuildRequires:	python3-distutils-pytest

--- a/setup.py
+++ b/setup.py
@@ -126,8 +126,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -136,4 +134,3 @@ setup(
         ],
     cmdclass = {'build_py': build_py, 'sdist': sdist, 'init_py': init_py},
 )
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ class TmpDir(object):
         self.dir = Path(tempfile.mkdtemp(prefix="archive-tools-test-"))
     def cleanup(self):
         if self.dir and _cleanup:
-            shutil.rmtree(str(self.dir))
+            shutil.rmtree(self.dir)
         self.dir = None
     def __enter__(self):
         return self.dir
@@ -116,7 +116,7 @@ def _set_fs_attrs(path, mode, mtime):
     if mode is not None:
         path.chmod(mode)
     if mtime is not None:
-        os.utime(str(path), (mtime, mtime), follow_symlinks=False)
+        os.utime(path, (mtime, mtime), follow_symlinks=False)
 
 class DataItem:
 
@@ -179,7 +179,7 @@ class DataFile(DataFileOrDir):
     def create(self, main_dir):
         path = main_dir / self.path
         path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(str(gettestdata(self.path.name)), str(path))
+        shutil.copy(gettestdata(self.path.name), path)
         _set_fs_attrs(path, self.mode, self.mtime)
 
 class DataRandomFile(DataFileOrDir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,13 +112,6 @@ def _get_checksums():
             checksums[fp] = cs
     return checksums
 
-def _mk_dir(path):
-    # path.mkdir(parents=True, exist_ok=True) requires Python 3.5.
-    try:
-        path.mkdir(parents=True)
-    except FileExistsError:
-        pass
-
 def _set_fs_attrs(path, mode, mtime):
     if mode is not None:
         path.chmod(mode)
@@ -164,7 +157,7 @@ class DataDir(DataFileOrDir):
 
     def create(self, main_dir):
         path = main_dir / self.path
-        _mk_dir(path)
+        path.mkdir(parents=True, exist_ok=True)
         _set_fs_attrs(path, self.mode, self.mtime)
 
 class DataFile(DataFileOrDir):
@@ -185,7 +178,7 @@ class DataFile(DataFileOrDir):
 
     def create(self, main_dir):
         path = main_dir / self.path
-        _mk_dir(path.parent)
+        path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(str(gettestdata(self.path.name)), str(path))
         _set_fs_attrs(path, self.mode, self.mtime)
 
@@ -209,7 +202,7 @@ class DataRandomFile(DataFileOrDir):
         data = bytearray(getrandbits(8) for _ in range(self._size))
         h.update(data)
         self._checksum = h.hexdigest()
-        _mk_dir(path.parent)
+        path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("wb") as f:
             f.write(data)
         _set_fs_attrs(path, self.mode, self.mtime)
@@ -230,7 +223,7 @@ class DataSymLink(DataItem):
 
     def create(self, main_dir):
         path = main_dir / self.path
-        _mk_dir(path.parent)
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.symlink_to(self.target)
         _set_fs_attrs(path, None, self.mtime)
 

--- a/tests/test_01_fileinfo.py
+++ b/tests/test_01_fileinfo.py
@@ -31,7 +31,7 @@ def test_dir(tmpdir):
 def test_fileinfo_lazy_checksum(test_dir, monkeypatch):
     """Check that checksums are calculated lazily.  Ref. #35.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     checksum_count = ChecksumCounter()
     entry = next(filter(lambda i: i.type == 'f', testdata))
     monkeypatch.setattr(archive.manifest, "checksum", checksum_count.checksum)

--- a/tests/test_01_manifest.py
+++ b/tests/test_01_manifest.py
@@ -45,7 +45,7 @@ def test_manifest_from_fileobj():
 def test_manifest_from_paths(test_dir, monkeypatch):
     """Create a manifest reading the files in test_dir.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     manifest = Manifest(paths=[Path("base")])
     head = manifest.head
     assert set(head.keys()) == {
@@ -63,7 +63,7 @@ def test_manifest_exclude_nonexistent(test_dir, monkeypatch):
 
     This is legal, but should have no effect.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     paths = [Path("base")]
     excludes = [Path("base", "non-existent.dat")]
     manifest = Manifest(paths=paths, excludes=excludes)
@@ -74,7 +74,7 @@ def test_manifest_exclude_nonexistent(test_dir, monkeypatch):
 def test_manifest_exclude_file(test_dir, monkeypatch):
     """Test excludes: excluding one single file.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     paths = [Path("base")]
     excludes = [Path("base", "msg.txt")]
     manifest = Manifest(paths=paths, excludes=excludes)
@@ -85,7 +85,7 @@ def test_manifest_exclude_file(test_dir, monkeypatch):
 def test_manifest_exclude_subdir(test_dir, monkeypatch):
     """Test excludes: excluding a subdirectory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     paths = [Path("base")]
     excludes = [Path("base", "data")]
     manifest = Manifest(paths=paths, excludes=excludes)
@@ -96,7 +96,7 @@ def test_manifest_exclude_subdir(test_dir, monkeypatch):
 def test_manifest_exclude_samelevel(test_dir, monkeypatch):
     """Test excludes: exclude things explictely named in paths.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     paths = [Path("base", "data"), Path("base", "empty")]
     excludes = [paths[1]]
     manifest = Manifest(paths=paths, excludes=excludes)
@@ -108,7 +108,7 @@ def test_manifest_exclude_explicit_include(test_dir, monkeypatch):
     """Test excludes: it is possible to explicitely include files, even if
     their parent directory is excluded.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     paths = [Path("base"), Path("base", "data", "rnd.dat")]
     excludes = [Path("base", "data")]
     manifest = Manifest(paths=paths, excludes=excludes)
@@ -119,7 +119,7 @@ def test_manifest_exclude_explicit_include(test_dir, monkeypatch):
 def test_manifest_from_fileinfos(test_dir, monkeypatch):
     """Create a manifest providing an iterable of fileinfos.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     fileinfos = FileInfo.iterpaths([Path("base")], set())
     manifest = Manifest(fileinfos=fileinfos)
     head = manifest.head
@@ -136,7 +136,7 @@ def test_manifest_from_fileinfos(test_dir, monkeypatch):
 def test_manifest_sort(test_dir, monkeypatch):
     """Test the Manifest.sort() method.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     manifest = Manifest(paths=[Path("base")])
     check_manifest(manifest, testdata)
     fileinfos = set(manifest)
@@ -175,6 +175,6 @@ def test_manifest_sort(test_dir, monkeypatch):
 def test_manifest_tags(test_dir, monkeypatch, tags, expected):
     """Set tags in a manifest reading the files in test_dir.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     manifest = Manifest(paths=[Path("base")], tags=tags)
     assert manifest.tags == expected

--- a/tests/test_02_create.py
+++ b/tests/test_02_create.py
@@ -54,7 +54,7 @@ def dep_testcase(request, testcase):
 def test_create(test_dir, monkeypatch, testcase):
     compression, abspath = testcase
     require_compression(compression)
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = Path(archive_name(ext=compression, tags=[absflag(abspath)]))
     if abspath:
         paths = [test_dir / "base"]
@@ -89,7 +89,7 @@ def test_check_content(test_dir, dep_testcase, inclmeta):
     flag = absflag(abspath)
     archive_path = test_dir / archive_name(ext=compression, tags=[flag])
     outdir = test_dir / "out"
-    shutil.rmtree(str(outdir), ignore_errors=True)
+    shutil.rmtree(outdir, ignore_errors=True)
     outdir.mkdir()
     if abspath:
         cwd = outdir / "archive" / test_dir.relative_to(test_dir.anchor)
@@ -102,7 +102,7 @@ def test_check_content(test_dir, dep_testcase, inclmeta):
         assert (outdir / f).is_file() == inclmeta
     try:
         sha256 = subprocess.Popen([sha256sum, "--check"], 
-                                  cwd=str(cwd), stdin=subprocess.PIPE)
+                                  cwd=cwd, stdin=subprocess.PIPE)
     except FileNotFoundError:
         pytest.skip("%s program not found" % sha256sum)
     for f in testdata:

--- a/tests/test_02_diff_manifest.py
+++ b/tests/test_02_diff_manifest.py
@@ -37,7 +37,7 @@ def test_dir(tmpdir):
 
 @pytest.fixture(scope="function")
 def test_data(request, test_dir):
-    shutil.rmtree(str(test_dir / "base"), ignore_errors=True)
+    shutil.rmtree(test_dir / "base", ignore_errors=True)
     with Archive().open(test_dir / "archive.tar") as archive:
         archive.extract(test_dir)
     return test_dir
@@ -45,7 +45,7 @@ def test_data(request, test_dir):
 def test_diff_manifest_equal(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having equal content.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
@@ -56,7 +56,7 @@ def test_diff_manifest_equal(test_data, testname, monkeypatch):
 def test_diff_manifest_metadata(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having one file's metadata modified.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
@@ -73,12 +73,12 @@ def test_diff_manifest_metadata(test_data, testname, monkeypatch):
 def test_diff_manifest_modified_file(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having one file's content modified.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
     p = base_dir / "rnd.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(p))
+    shutil.copy(gettestdata("rnd2.dat"), p)
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1
@@ -90,7 +90,7 @@ def test_diff_manifest_modified_file(test_data, testname, monkeypatch):
 def test_diff_manifest_symlink_target(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having one symlink's target modified.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
@@ -108,7 +108,7 @@ def test_diff_manifest_symlink_target(test_data, testname, monkeypatch):
 def test_diff_manifest_wrong_type(test_data, testname, monkeypatch):
     """Diff two fileinfo lists with one entry having a wrong type.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
@@ -127,7 +127,7 @@ def test_diff_manifest_wrong_type(test_data, testname, monkeypatch):
 def test_diff_manifest_missing_files(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having one file's name changed.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
@@ -151,12 +151,12 @@ def test_diff_manifest_missing_files(test_data, testname, monkeypatch):
 def test_diff_manifest_mult(test_data, testname, monkeypatch):
     """Diff two fileinfo lists having multiple differences.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
     pm = base_dir / "data" / "rnd.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(pm))
+    shutil.copy(gettestdata("rnd2.dat"), pm)
     p1 = base_dir / "msg.txt"
     p2 = base_dir / "o.txt"
     p1.rename(p2)
@@ -181,12 +181,12 @@ def test_diff_manifest_mult(test_data, testname, monkeypatch):
 def test_diff_manifest_dircontent(test_data, testname, monkeypatch):
     """Diff two fileinfo lists with one subdirectory missing.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
     pd = base_dir / "data"
-    shutil.rmtree(str(pd))
+    shutil.rmtree(pd)
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 2
@@ -207,12 +207,12 @@ def test_diff_manifest_add_file_last(test_data, testname, monkeypatch):
     The implementation of the corresponding command line tool used to
     have a flaw in this particular case, ref. #55.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
     p = base_dir / "zzz.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(p))
+    shutil.copy(gettestdata("rnd2.dat"), p)
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1

--- a/tests/test_03_create_dedup.py
+++ b/tests/test_03_create_dedup.py
@@ -74,7 +74,7 @@ def test_check_content(test_dir, dep_testcase):
     outdir = test_dir / "out"
     shutil.rmtree(outdir, ignore_errors=True)
     outdir.mkdir()
-    with tarfile.open(str(archive_path), "r") as tarf:
+    with tarfile.open(archive_path, "r") as tarf:
         tarf.extractall(path=str(outdir))
     try:
         sha256 = subprocess.Popen([sha256sum, "--check"], 

--- a/tests/test_03_create_dedup.py
+++ b/tests/test_03_create_dedup.py
@@ -31,9 +31,9 @@ sha256sum = "sha256sum"
 def test_dir(tmpdir):
     setup_testdata(tmpdir, testdata)
     sf = next(filter(lambda f: f.path == src, testdata))
-    os.link(str(tmpdir / src), str(tmpdir / dest_lnk))
+    os.link(tmpdir / src, tmpdir / dest_lnk)
     testdata.append(DataFile(dest_lnk, sf.mode, checksum=sf.checksum))
-    shutil.copy(str(tmpdir / src), str(tmpdir / dest_cp))
+    shutil.copy(tmpdir / src, tmpdir / dest_cp)
     testdata.append(DataFile(dest_cp, sf.mode, checksum=sf.checksum))
     return tmpdir
 
@@ -55,7 +55,7 @@ def dep_testcase(request, testcase):
 @pytest.mark.dependency()
 def test_create(test_dir, monkeypatch, testcase):
     dedup = testcase
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = Path(archive_name(tags=[dedup.value]))
     paths = [Path("base")]
     Archive().create(archive_path, '', paths, dedup=dedup)
@@ -72,13 +72,13 @@ def test_check_content(test_dir, dep_testcase):
     dedup = dep_testcase
     archive_path = test_dir / archive_name(tags=[dedup.value])
     outdir = test_dir / "out"
-    shutil.rmtree(str(outdir), ignore_errors=True)
+    shutil.rmtree(outdir, ignore_errors=True)
     outdir.mkdir()
     with tarfile.open(str(archive_path), "r") as tarf:
         tarf.extractall(path=str(outdir))
     try:
         sha256 = subprocess.Popen([sha256sum, "--check"], 
-                                  cwd=str(outdir), stdin=subprocess.PIPE)
+                                  cwd=outdir, stdin=subprocess.PIPE)
     except FileNotFoundError:
         pytest.skip("%s program not found" % sha256sum)
     for f in testdata:

--- a/tests/test_03_create_errors.py
+++ b/tests/test_03_create_errors.py
@@ -111,7 +111,7 @@ def test_create_duplicate_metadata(test_dir, testname, monkeypatch):
     monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
-    with TemporaryFile(dir=str(test_dir)) as tmpf:
+    with TemporaryFile(dir=test_dir) as tmpf:
         archive = Archive()
         tmpf.write("Hello world!\n".encode("ascii"))
         tmpf.seek(0)
@@ -127,7 +127,7 @@ def test_create_metadata_vs_content(test_dir, testname, monkeypatch):
     monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
-    with TemporaryFile(dir=str(test_dir)) as tmpf:
+    with TemporaryFile(dir=test_dir) as tmpf:
         archive = Archive()
         tmpf.write("Hello world!\n".encode("ascii"))
         tmpf.seek(0)

--- a/tests/test_03_create_errors.py
+++ b/tests/test_03_create_errors.py
@@ -30,7 +30,7 @@ def test_dir(tmpdir):
 def test_create_empty(test_dir, testname, monkeypatch):
     """Creating an empty archive will be refused.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with pytest.raises(ArchiveCreateError):
         Archive().create(Path(name), "", [], basedir=Path("base"))
@@ -38,7 +38,7 @@ def test_create_empty(test_dir, testname, monkeypatch):
 def test_create_abs_basedir(test_dir, testname, monkeypatch):
     """Base dir must be a a relative path.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [Path("base")]
     basedir = test_dir / "base"
@@ -48,7 +48,7 @@ def test_create_abs_basedir(test_dir, testname, monkeypatch):
 def test_create_mixing_abs_rel(test_dir, testname, monkeypatch):
     """Mixing absolute and relative paths is not allowed.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [ Path("base", "msg.txt"), test_dir / "base" / "data" ]
     with pytest.raises(ArchiveCreateError):
@@ -57,7 +57,7 @@ def test_create_mixing_abs_rel(test_dir, testname, monkeypatch):
 def test_create_rel_not_in_base(test_dir, testname, monkeypatch):
     """Relative paths must be in the base directory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [ Path("other", "rnd.dat") ]
     with pytest.raises(ArchiveCreateError):
@@ -66,7 +66,7 @@ def test_create_rel_not_in_base(test_dir, testname, monkeypatch):
 def test_create_norm_path(test_dir, testname, monkeypatch):
     """Items in paths must be normalized.  (Issue #6)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [ Path("base"), Path("base/../../../etc/passwd") ]
     with pytest.raises(ArchiveCreateError):
@@ -75,7 +75,7 @@ def test_create_norm_path(test_dir, testname, monkeypatch):
 def test_create_rel_check_basedir(test_dir, testname, monkeypatch):
     """Base directory must be a directory.  (Issue #9)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("msg.txt")
     with pytest.raises(ArchiveCreateError):
@@ -92,7 +92,7 @@ def test_create_rel_no_manifest_file(test_dir, testname, monkeypatch):
     /.manifest.yaml to the archive.  Obviously, we cannot create such
     a file for the test.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     base = Path("base")
     manifest = base / ".manifest.yaml"
@@ -108,7 +108,7 @@ def test_create_duplicate_metadata(test_dir, testname, monkeypatch):
     """Add additional custom metadata to the archive,
     using a name that is already taken.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
     with TemporaryFile(dir=str(test_dir)) as tmpf:
@@ -124,7 +124,7 @@ def test_create_metadata_vs_content(test_dir, testname, monkeypatch):
     """Add additional custom metadata to the archive,
     using a name that conflicts with a content file.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
     with TemporaryFile(dir=str(test_dir)) as tmpf:
@@ -140,7 +140,7 @@ def test_create_fileinfos_missing_checksum(test_dir, testname, monkeypatch):
     """When an archive is created from precompiled fileinfos,
     they must already contain suitable checksums.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with monkeypatch.context() as m:
         m.setattr(FileInfo, "Checksums", ['md5'])
@@ -159,7 +159,7 @@ def test_create_manifest_missing_checksum(test_dir, testname, monkeypatch):
     """Same as last test, but now creating the archive from a precompiled
     manifest.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with monkeypatch.context() as m:
         m.setattr(FileInfo, "Checksums", ['md5'])

--- a/tests/test_03_create_exclude.py
+++ b/tests/test_03_create_exclude.py
@@ -31,7 +31,7 @@ def test_dir(tmpdir):
 def test_create_exclude_file(test_dir, testname, monkeypatch):
     """Exclude one single file.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [Path("base")]
     excludes = [Path("base", "msg.txt")]
@@ -45,7 +45,7 @@ def test_create_exclude_file(test_dir, testname, monkeypatch):
 def test_create_exclude_subdir(test_dir, testname, monkeypatch):
     """Exclude a subdirectory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [Path("base")]
     excludes = [Path("base", "data")]
@@ -59,7 +59,7 @@ def test_create_exclude_subdir(test_dir, testname, monkeypatch):
 def test_create_exclude_samelevel(test_dir, testname, monkeypatch):
     """Exclude a directory explictely named in paths.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [Path("base", "data"), Path("base", "empty")]
     excludes = [paths[1]]
@@ -74,7 +74,7 @@ def test_create_exclude_explicit_include(test_dir, testname, monkeypatch):
     """Exclude a directory, but explicitely include an item in that
     directory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = [Path("base"), Path("base", "data", "rnd1.dat")]
     excludes = [Path("base", "data")]

--- a/tests/test_03_create_fileinfos.py
+++ b/tests/test_03_create_fileinfos.py
@@ -30,7 +30,7 @@ def test_dir(tmpdir):
 def test_create_fileinfos_list(test_dir, monkeypatch):
     """Create the archive from a list of FileInfo objects.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     fileinfos = list(FileInfo.iterpaths([Path("base")], set()))
     archive_path = Path("archive-fi-list.tar")
     Archive().create(archive_path, "", fileinfos=fileinfos)
@@ -41,7 +41,7 @@ def test_create_fileinfos_list(test_dir, monkeypatch):
 def test_create_fileinfos_generator(test_dir, monkeypatch):
     """Create the archive from FileInfo.iterpaths() which returns a generator.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     fileinfos = FileInfo.iterpaths([Path("base")], set())
     archive_path = Path("archive-fi-generator.tar")
     Archive().create(archive_path, "", fileinfos=fileinfos)
@@ -53,7 +53,7 @@ def test_create_fileinfos_manifest(test_dir, monkeypatch):
     """Create the archive from a Manifest.
     A Manifest is an iterable of FileInfo objects.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     manifest = Manifest(paths=[Path("base")])
     archive_path = Path("archive-fi-manifest.tar")
     Archive().create(archive_path, "", fileinfos=manifest)
@@ -66,7 +66,7 @@ def test_create_fileinfos_subset(test_dir, monkeypatch):
     This test verifies that creating an archive from fileinfos does
     not implicitly descend subdirectories.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     excludes = [Path("base", "data", "rnd.dat")]
     fileinfos = FileInfo.iterpaths([Path("base")], set(excludes))
     data = sub_testdata(testdata, excludes[0])

--- a/tests/test_03_create_filetype.py
+++ b/tests/test_03_create_filetype.py
@@ -44,7 +44,7 @@ class tmp_fifo():
     """
     def __init__(self, path):
         self.path = path
-        os.mkfifo(str(self.path))
+        os.mkfifo(self.path)
     def __enter__(self):
         return self.path
     def __exit__(self, type, value, tb):
@@ -53,7 +53,7 @@ class tmp_fifo():
 def test_create_invalid_file_socket(test_dir, testname, monkeypatch):
     """Create an archive from a directory containing a socket.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
     fp = p / "socket"
@@ -68,7 +68,7 @@ def test_create_invalid_file_socket(test_dir, testname, monkeypatch):
 def test_create_invalid_file_fifo(test_dir, testname, monkeypatch):
     """Create an archive from a directory containing a FIFO.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     p = Path("base")
     fp = p / "fifo"

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -27,7 +27,7 @@ def test_dir(tmpdir):
 def test_create_default_basedir_rel(test_dir, monkeypatch):
     """Check the default basedir with relative paths.  (Issue #8)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = "archive-rel.tar"
     p = Path("base", "data")
     Archive().create(archive_path, "", [p])
@@ -39,7 +39,7 @@ def test_create_default_basedir_rel(test_dir, monkeypatch):
 def test_create_default_basedir_abs(test_dir, monkeypatch):
     """Check the default basedir with absolute paths.  (Issue #8)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = Path("archive-abs.tar")
     p = test_dir / Path("base", "data")
     Archive().create(archive_path, "", [p])
@@ -51,7 +51,7 @@ def test_create_default_basedir_abs(test_dir, monkeypatch):
 def test_create_sorted(test_dir, monkeypatch):
     """The entries in the manifest should be sorted.  (Issue #11)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = Path("archive-sort.tar")
     files = [ Path("base", fn) for fn in ("c", "a", "d", "b") ]
     for p in files:
@@ -69,7 +69,7 @@ def test_create_sorted(test_dir, monkeypatch):
 def test_create_custom_metadata(test_dir, monkeypatch):
     """Add additional custom metadata to the archive.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = Path("archive-custom-md.tar")
     p = Path("base", "data")
     with TemporaryFile(dir=str(test_dir)) as tmpf:
@@ -90,7 +90,7 @@ def test_create_custom_metadata(test_dir, monkeypatch):
 def test_create_add_symlink(test_dir, monkeypatch):
     """Check adding explicitly adding a symbolic link.  (Issue #37)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = "archive-symlink.tar"
     paths = [Path("base", "data", "misc"), Path("base", "data", "s.dat")]
     data = [ testdata[i] for i in (1,3,4) ]
@@ -108,7 +108,7 @@ def test_create_add_symlink(test_dir, monkeypatch):
 def test_create_tags(test_dir, monkeypatch, tags, expected):
     """Test setting tags.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = archive_name(tags=["tags"], counter="create_tags")
     Archive().create(archive_path, "", [Path("base")], tags=tags)
     with Archive().open(archive_path) as archive:

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -72,7 +72,7 @@ def test_create_custom_metadata(test_dir, monkeypatch):
     monkeypatch.chdir(test_dir)
     archive_path = Path("archive-custom-md.tar")
     p = Path("base", "data")
-    with TemporaryFile(dir=str(test_dir)) as tmpf:
+    with TemporaryFile(dir=test_dir) as tmpf:
         archive = Archive()
         tmpf.write("Hello world!\n".encode("ascii"))
         tmpf.seek(0)

--- a/tests/test_03_create_workdir.py
+++ b/tests/test_03_create_workdir.py
@@ -24,7 +24,7 @@ def test_create_workdir(test_dir, monkeypatch, abs_wd):
     """Pass an absolute or relative workdir to Archive.create().
     (Issue #53)
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     if abs_wd:
         workdir = test_dir / "work"
     else:

--- a/tests/test_03_verify_errors.py
+++ b/tests/test_03_verify_errors.py
@@ -28,7 +28,7 @@ testdata = [
 
 @pytest.fixture(scope="function")
 def test_data(tmpdir, monkeypatch):
-    monkeypatch.chdir(str(tmpdir))
+    monkeypatch.chdir(tmpdir)
     shutil.rmtree("base", ignore_errors=True)
     setup_testdata(tmpdir, testdata)
     manifest = Manifest(paths=[Path("base")])
@@ -77,9 +77,9 @@ def test_verify_missing_metadata_item(test_data, testname):
 def test_verify_missing_file(test_data, testname):
     name = archive_name(tags=[testname])
     path = Path("base", "msg.txt")
-    mtime_parent = os.stat(str(path.parent)).st_mtime
+    mtime_parent = os.stat(path.parent).st_mtime
     path.unlink()
-    os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
+    os.utime(path.parent, times=(mtime_parent, mtime_parent))
     create_archive(name)
     with Archive().open(Path(name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
@@ -110,7 +110,7 @@ def test_verify_wrong_mtime(test_data, testname):
     name = archive_name(tags=[testname])
     path = Path("base", "msg.txt")
     hour_ago = time.time() - 3600
-    os.utime(str(path), times=(hour_ago, hour_ago))
+    os.utime(path, times=(hour_ago, hour_ago))
     create_archive(name)
     with Archive().open(Path(name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
@@ -120,14 +120,14 @@ def test_verify_wrong_mtime(test_data, testname):
 def test_verify_wrong_type(test_data, testname):
     name = archive_name(tags=[testname])
     path = Path("base", "msg.txt")
-    mode = os.stat(str(path)).st_mode
-    mtime = os.stat(str(path)).st_mtime
-    mtime_parent = os.stat(str(path.parent)).st_mtime
+    mode = os.stat(path).st_mode
+    mtime = os.stat(path).st_mtime
+    mtime_parent = os.stat(path.parent).st_mtime
     path.unlink()
     path.mkdir()
     path.chmod(mode)
-    os.utime(str(path), times=(mtime, mtime))
-    os.utime(str(path.parent), times=(mtime_parent, mtime_parent))
+    os.utime(path, times=(mtime, mtime))
+    os.utime(path.parent, times=(mtime_parent, mtime_parent))
     create_archive(name)
     with Archive().open(Path(name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:
@@ -137,14 +137,14 @@ def test_verify_wrong_type(test_data, testname):
 def test_verify_wrong_checksum(test_data, testname):
     name = archive_name(tags=[testname])
     path = Path("base", "data", "rnd.dat")
-    stat = os.stat(str(path))
+    stat = os.stat(path)
     mode = stat.st_mode
     mtime = stat.st_mtime
     size = stat.st_size
     with path.open("wb") as f:
         f.write(b'0' * size)
     path.chmod(mode)
-    os.utime(str(path), times=(mtime, mtime))
+    os.utime(path, times=(mtime, mtime))
     create_archive(name)
     with Archive().open(Path(name)) as archive:
         with pytest.raises(ArchiveIntegrityError) as err:

--- a/tests/test_03_verify_errors.py
+++ b/tests/test_03_verify_errors.py
@@ -61,7 +61,7 @@ def test_verify_missing_metadata_item(test_data, testname):
     manifest.add_metadata(Path("base", ".manifest.yaml"))
     manifest.add_metadata(Path("base", ".msg.txt"))
     with tarfile.open(name, "w") as tarf:
-        with tempfile.TemporaryFile(dir=str(test_data)) as tmpf:
+        with tempfile.TemporaryFile(dir=test_data) as tmpf:
             manifest.write(tmpf)
             tmpf.seek(0)
             ti = tarf.gettarinfo(arcname="base/.manifest.yaml", 

--- a/tests/test_04_cli.py
+++ b/tests/test_04_cli.py
@@ -85,7 +85,7 @@ def test_cli_ls(test_dir, dep_testcase):
     flag = absflag(abspath)
     archive_path = test_dir / archive_name(ext=compression, tags=[flag])
     prefix_dir = test_dir if abspath else Path(".")
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -106,7 +106,7 @@ def test_cli_checksums(test_dir, dep_testcase):
     compression, abspath = dep_testcase
     flag = absflag(abspath)
     archive_path = test_dir / archive_name(ext=compression, tags=[flag])
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", "--format=checksum", str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -133,7 +133,7 @@ def test_cli_info(test_dir, dep_testcase):
     for entry in testdata:
         if entry.type in types_done:
             continue
-        with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        with TemporaryFile(mode="w+t", dir=test_dir) as f:
             args = ["info", str(archive_path), str(prefix_dir / entry.path)]
             callscript("archive-tool.py", args, stdout=f)
             f.seek(0)

--- a/tests/test_04_cli.py
+++ b/tests/test_04_cli.py
@@ -53,7 +53,7 @@ def dep_testcase(request, testcase):
 def test_cli_create(test_dir, monkeypatch, testcase):
     compression, abspath = testcase
     require_compression(compression)
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = archive_name(ext=compression, tags=[absflag(abspath)])
     if abspath:
         paths = str(test_dir / "base")
@@ -110,7 +110,7 @@ def test_cli_checksums(test_dir, dep_testcase):
         args = ["ls", "--format=checksum", str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
-        cwd = None if abspath else str(test_dir)
+        cwd = None if abspath else test_dir
         try:
             sha256 = subprocess.Popen([sha256sum, "--check"],
                                       cwd=cwd, stdin=subprocess.PIPE)

--- a/tests/test_04_cli_check.py
+++ b/tests/test_04_cli_check.py
@@ -39,13 +39,13 @@ def extract_archive(testname, test_dir):
     archive_path = test_dir / "archive.tar"
     check_dir = test_dir / testname
     check_dir.mkdir()
-    with tarfile.open(str(archive_path), "r") as tarf:
+    with tarfile.open(archive_path, "r") as tarf:
         tarf.extractall(path=str(check_dir))
     return check_dir
 
 def test_check_allmatch(test_dir, copy_data, monkeypatch):
     monkeypatch.chdir(copy_data)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -57,7 +57,7 @@ def test_check_allmatch_default_files(test_dir, copy_data, monkeypatch):
     basedir.  Ref. #45.
     """
     monkeypatch.chdir(copy_data)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar")]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -68,7 +68,7 @@ def test_check_add_file(test_dir, copy_data, monkeypatch):
     fp = Path("base", "new_msg.txt")
     with fp.open("wt") as f:
         print("Greeting!", file=f)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -79,7 +79,7 @@ def test_check_change_type(test_dir, copy_data, monkeypatch):
     fp = Path("base", "s.dat")
     fp.unlink()
     shutil.copy2(Path("base", "data", "rnd.dat"), fp)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -89,7 +89,7 @@ def test_check_touch_file(test_dir, copy_data, monkeypatch):
     monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     fp.touch()
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -102,7 +102,7 @@ def test_check_modify_file(test_dir, copy_data, monkeypatch):
     with fp.open("wb") as f:
         f.write(b" " * st.st_size)
     os.utime(fp, (st.st_mtime, st.st_mtime))
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -113,7 +113,7 @@ def test_check_symlink_target(test_dir, copy_data, monkeypatch):
     fp = Path("base", "s.dat")
     fp.unlink()
     fp.symlink_to(Path("msg.txt"))
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -121,7 +121,7 @@ def test_check_symlink_target(test_dir, copy_data, monkeypatch):
 
 def test_check_present_allmatch(test_dir, copy_data, monkeypatch):
     monkeypatch.chdir(copy_data)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -132,7 +132,7 @@ def test_check_present_add_file(test_dir, copy_data, monkeypatch):
     fp = Path("base", "new_msg.txt")
     with fp.open("wt") as f:
         print("Greeting!", file=f)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -143,7 +143,7 @@ def test_check_present_change_type(test_dir, copy_data, monkeypatch):
     fp = Path("base", "s.dat")
     fp.unlink()
     shutil.copy2(Path("base", "data", "rnd.dat"), fp)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -153,7 +153,7 @@ def test_check_present_touch_file(test_dir, copy_data, monkeypatch):
     monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     fp.touch()
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -166,7 +166,7 @@ def test_check_present_modify_file(test_dir, copy_data, monkeypatch):
     with fp.open("wb") as f:
         f.write(b" " * st.st_size)
     os.utime(fp, (st.st_mtime, st.st_mtime))
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -177,7 +177,7 @@ def test_check_present_symlink_target(test_dir, copy_data, monkeypatch):
     fp = Path("base", "s.dat")
     fp.unlink()
     fp.symlink_to(Path("msg.txt"))
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -192,7 +192,7 @@ def test_check_extract_archive(test_dir, extract_archive, monkeypatch):
     not listed in the manifest.  Issue #25.
     """
     monkeypatch.chdir(extract_archive)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -206,7 +206,7 @@ def test_check_extract_archive_custom_metadata(test_dir, testname, monkeypatch):
     having custom metadata.  Issue #25.
     """
     archive_path = test_dir / "archive-custom-md.tar"
-    with TemporaryFile(dir=str(test_dir)) as tmpf:
+    with TemporaryFile(dir=test_dir) as tmpf:
         archive = Archive()
         tmpf.write("Hello world!\n".encode("ascii"))
         tmpf.seek(0)
@@ -215,9 +215,9 @@ def test_check_extract_archive_custom_metadata(test_dir, testname, monkeypatch):
     check_dir = test_dir / testname
     check_dir.mkdir()
     monkeypatch.chdir(check_dir)
-    with tarfile.open(str(archive_path), "r") as tarf:
+    with tarfile.open(archive_path, "r") as tarf:
         tarf.extractall()
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", str(archive_path), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -234,7 +234,7 @@ def test_check_present_extract_archive(test_dir, extract_archive, monkeypatch):
     """
     monkeypatch.chdir(extract_archive)
     all_files = all_test_files | { 'base/.manifest.yaml' }
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -250,7 +250,7 @@ def test_check_prefix_allmatch(test_dir, copy_data, monkeypatch):
     archive_path = test_dir / "archive.tar"
     prefix = Path("base", "data")
     monkeypatch.chdir(copy_data / prefix)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--prefix", str(prefix), str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -265,7 +265,7 @@ def test_check_prefix_present_allmatch(test_dir, copy_data, monkeypatch):
     archive_path = test_dir / "archive.tar"
     prefix = Path("base", "data")
     monkeypatch.chdir(copy_data / prefix)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--prefix", str(prefix), "--present", 
                 str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
@@ -282,7 +282,7 @@ def test_check_prefix_extract(test_dir, extract_archive, monkeypatch):
     archive_path = test_dir / "archive.tar"
     prefix = Path("base")
     monkeypatch.chdir(extract_archive / prefix)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--prefix", str(prefix), str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -301,7 +301,7 @@ def test_check_prefix_present_extract(test_dir, extract_archive, monkeypatch):
         str(f.path.relative_to(prefix))
         for f in testdata if f.type in {'f', 'l'}
     } | { '.manifest.yaml' }
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--prefix", str(prefix), "--present", 
                 str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
@@ -314,9 +314,9 @@ def test_check_stdin(test_dir, copy_data, monkeypatch):
     new_file = Path("base", "new_msg.txt")
     with new_file.open("wt") as f:
         print("Greeting!", file=f)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_out:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f_out:
         args = ["check", "--stdin", str(test_dir / "archive.tar")]
-        with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_in:
+        with TemporaryFile(mode="w+t", dir=test_dir) as f_in:
             print(old_file, file=f_in)
             print(new_file, file=f_in)
             f_in.seek(0)
@@ -330,9 +330,9 @@ def test_check_stdin_present(test_dir, copy_data, monkeypatch):
     new_file = Path("base", "new_msg.txt")
     with new_file.open("wt") as f:
         print("Greeting!", file=f)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_out:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f_out:
         args = ["check", "--present", "--stdin", str(test_dir / "archive.tar")]
-        with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_in:
+        with TemporaryFile(mode="w+t", dir=test_dir) as f_in:
             print(old_file, file=f_in)
             print(new_file, file=f_in)
             f_in.seek(0)

--- a/tests/test_04_cli_check.py
+++ b/tests/test_04_cli_check.py
@@ -31,8 +31,7 @@ def test_dir(tmpdir):
 @pytest.fixture(scope="function")
 def copy_data(testname, test_dir):
     copy_dir = test_dir / testname
-    shutil.copytree(str(test_dir / "base"), str(copy_dir / "base"), 
-                    symlinks=True)
+    shutil.copytree(test_dir / "base", copy_dir / "base", symlinks=True)
     return copy_dir
 
 @pytest.fixture(scope="function")
@@ -45,7 +44,7 @@ def extract_archive(testname, test_dir):
     return check_dir
 
 def test_check_allmatch(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -57,7 +56,7 @@ def test_check_allmatch_default_files(test_dir, copy_data, monkeypatch):
     Rely on the fact that the file argument defaults to the archives's
     basedir.  Ref. #45.
     """
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", str(test_dir / "archive.tar")]
         callscript("archive-tool.py", args, stdout=f)
@@ -65,7 +64,7 @@ def test_check_allmatch_default_files(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == set()
 
 def test_check_add_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "new_msg.txt")
     with fp.open("wt") as f:
         print("Greeting!", file=f)
@@ -76,10 +75,10 @@ def test_check_add_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == {str(fp)}
 
 def test_check_change_type(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "s.dat")
     fp.unlink()
-    shutil.copy2(str(Path("base", "data", "rnd.dat")), str(fp))
+    shutil.copy2(Path("base", "data", "rnd.dat"), fp)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -87,7 +86,7 @@ def test_check_change_type(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == {str(fp)}
 
 def test_check_touch_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     fp.touch()
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
@@ -97,12 +96,12 @@ def test_check_touch_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == {str(fp)}
 
 def test_check_modify_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     st = fp.stat()
     with fp.open("wb") as f:
         f.write(b" " * st.st_size)
-    os.utime(str(fp), (st.st_mtime, st.st_mtime))
+    os.utime(fp, (st.st_mtime, st.st_mtime))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -110,7 +109,7 @@ def test_check_modify_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == {str(fp)}
 
 def test_check_symlink_target(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "s.dat")
     fp.unlink()
     fp.symlink_to(Path("msg.txt"))
@@ -121,7 +120,7 @@ def test_check_symlink_target(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == {str(fp)}
 
 def test_check_present_allmatch(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -129,7 +128,7 @@ def test_check_present_allmatch(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == all_test_files
 
 def test_check_present_add_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "new_msg.txt")
     with fp.open("wt") as f:
         print("Greeting!", file=f)
@@ -140,10 +139,10 @@ def test_check_present_add_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
 def test_check_present_change_type(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "s.dat")
     fp.unlink()
-    shutil.copy2(str(Path("base", "data", "rnd.dat")), str(fp))
+    shutil.copy2(Path("base", "data", "rnd.dat"), fp)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -151,7 +150,7 @@ def test_check_present_change_type(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
 def test_check_present_touch_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     fp.touch()
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
@@ -161,12 +160,12 @@ def test_check_present_touch_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
 def test_check_present_modify_file(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")
     st = fp.stat()
     with fp.open("wb") as f:
         f.write(b" " * st.st_size)
-    os.utime(str(fp), (st.st_mtime, st.st_mtime))
+    os.utime(fp, (st.st_mtime, st.st_mtime))
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -174,7 +173,7 @@ def test_check_present_modify_file(test_dir, copy_data, monkeypatch):
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
 def test_check_present_symlink_target(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     fp = Path("base", "s.dat")
     fp.unlink()
     fp.symlink_to(Path("msg.txt"))
@@ -192,7 +191,7 @@ def test_check_extract_archive(test_dir, extract_archive, monkeypatch):
     file to be missing in the archive, even though these metadata are
     not listed in the manifest.  Issue #25.
     """
-    monkeypatch.chdir(str(extract_archive))
+    monkeypatch.chdir(extract_archive)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", str(test_dir / "archive.tar"), "base"]
         callscript("archive-tool.py", args, stdout=f)
@@ -215,7 +214,7 @@ def test_check_extract_archive_custom_metadata(test_dir, testname, monkeypatch):
         archive.create(archive_path, "", [Path("base")], workdir=test_dir)
     check_dir = test_dir / testname
     check_dir.mkdir()
-    monkeypatch.chdir(str(check_dir))
+    monkeypatch.chdir(check_dir)
     with tarfile.open(str(archive_path), "r") as tarf:
         tarf.extractall()
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
@@ -233,7 +232,7 @@ def test_check_present_extract_archive(test_dir, extract_archive, monkeypatch):
     metadata such as the manifest file, even though these metadata are
     not listed in the manifest.  Issue #25.
     """
-    monkeypatch.chdir(str(extract_archive))
+    monkeypatch.chdir(extract_archive)
     all_files = all_test_files | { 'base/.manifest.yaml' }
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--present", str(test_dir / "archive.tar"), "base"]
@@ -250,7 +249,7 @@ def test_check_prefix_allmatch(test_dir, copy_data, monkeypatch):
     """
     archive_path = test_dir / "archive.tar"
     prefix = Path("base", "data")
-    monkeypatch.chdir(str(copy_data / prefix))
+    monkeypatch.chdir(copy_data / prefix)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--prefix", str(prefix), str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
@@ -265,7 +264,7 @@ def test_check_prefix_present_allmatch(test_dir, copy_data, monkeypatch):
     """
     archive_path = test_dir / "archive.tar"
     prefix = Path("base", "data")
-    monkeypatch.chdir(str(copy_data / prefix))
+    monkeypatch.chdir(copy_data / prefix)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--prefix", str(prefix), "--present", 
                 str(archive_path), "."]
@@ -282,7 +281,7 @@ def test_check_prefix_extract(test_dir, extract_archive, monkeypatch):
     """
     archive_path = test_dir / "archive.tar"
     prefix = Path("base")
-    monkeypatch.chdir(str(extract_archive / prefix))
+    monkeypatch.chdir(extract_archive / prefix)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["check", "--prefix", str(prefix), str(archive_path), "."]
         callscript("archive-tool.py", args, stdout=f)
@@ -297,7 +296,7 @@ def test_check_prefix_present_extract(test_dir, extract_archive, monkeypatch):
     """
     archive_path = test_dir / "archive.tar"
     prefix = Path("base")
-    monkeypatch.chdir(str(extract_archive / prefix))
+    monkeypatch.chdir(extract_archive / prefix)
     all_files = {
         str(f.path.relative_to(prefix))
         for f in testdata if f.type in {'f', 'l'}
@@ -310,7 +309,7 @@ def test_check_prefix_present_extract(test_dir, extract_archive, monkeypatch):
         assert set(get_output(f)) == all_files
 
 def test_check_stdin(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     old_file = Path("base", "data", "rnd.dat")
     new_file = Path("base", "new_msg.txt")
     with new_file.open("wt") as f:
@@ -318,15 +317,15 @@ def test_check_stdin(test_dir, copy_data, monkeypatch):
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_out:
         args = ["check", "--stdin", str(test_dir / "archive.tar")]
         with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_in:
-            print(str(old_file), file=f_in)
-            print(str(new_file), file=f_in)
+            print(old_file, file=f_in)
+            print(new_file, file=f_in)
             f_in.seek(0)
             callscript("archive-tool.py", args, stdin=f_in, stdout=f_out)
         f_out.seek(0)
         assert set(get_output(f_out)) == {str(new_file)}
 
 def test_check_stdin_present(test_dir, copy_data, monkeypatch):
-    monkeypatch.chdir(str(copy_data))
+    monkeypatch.chdir(copy_data)
     old_file = Path("base", "data", "rnd.dat")
     new_file = Path("base", "new_msg.txt")
     with new_file.open("wt") as f:
@@ -334,8 +333,8 @@ def test_check_stdin_present(test_dir, copy_data, monkeypatch):
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_out:
         args = ["check", "--present", "--stdin", str(test_dir / "archive.tar")]
         with TemporaryFile(mode="w+t", dir=str(test_dir)) as f_in:
-            print(str(old_file), file=f_in)
-            print(str(new_file), file=f_in)
+            print(old_file, file=f_in)
+            print(new_file, file=f_in)
             f_in.seek(0)
             callscript("archive-tool.py", args, stdin=f_in, stdout=f_out)
         f_out.seek(0)

--- a/tests/test_04_cli_create_dedup.py
+++ b/tests/test_04_cli_create_dedup.py
@@ -29,9 +29,9 @@ sha256sum = "sha256sum"
 def test_dir(tmpdir):
     setup_testdata(tmpdir, testdata)
     sf = next(filter(lambda f: f.path == src, testdata))
-    os.link(str(tmpdir / src), str(tmpdir / dest_lnk))
+    os.link(tmpdir / src, tmpdir / dest_lnk)
     testdata.append(DataFile(dest_lnk, sf.mode, checksum=sf.checksum))
-    shutil.copy(str(tmpdir / src), str(tmpdir / dest_cp))
+    shutil.copy(tmpdir / src, tmpdir / dest_cp)
     testdata.append(DataFile(dest_cp, sf.mode, checksum=sf.checksum))
     return tmpdir
 
@@ -53,7 +53,7 @@ def dep_testcase(request, testcase):
 @pytest.mark.dependency()
 def test_cli_create(test_dir, monkeypatch, testcase):
     dedup = testcase
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = archive_name(tags=[dedup.value])
     basedir = "base"
     args = ["create", "--deduplicate", dedup.value, archive_path, basedir]

--- a/tests/test_04_cli_create_exclude.py
+++ b/tests/test_04_cli_create_exclude.py
@@ -31,7 +31,7 @@ def test_dir(tmpdir):
 def test_cli_create_exclude_dir(test_dir, testname, monkeypatch):
     """Exclude a single directory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = "base"
     exclude = Path("base", "data")
@@ -45,7 +45,7 @@ def test_cli_create_exclude_dir(test_dir, testname, monkeypatch):
 def test_cli_create_exclude_mult(test_dir, testname, monkeypatch):
     """Exclude multiple items.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     paths = "base"
     excludes = [
@@ -68,7 +68,7 @@ def test_cli_create_exclude_include(test_dir, testname, monkeypatch):
     """Exclude a directory, but explicitely include an item in that
     directory.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     exclude = Path("base", "data")
     include = Path("base", "data", "rnd1.dat")

--- a/tests/test_04_cli_create_misc.py
+++ b/tests/test_04_cli_create_misc.py
@@ -32,7 +32,7 @@ def test_dir(tmpdir):
 def test_cli_create_tags(test_dir, monkeypatch, tags, expected):
     """Set tags using the --tags argument.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     archive_path = archive_name(tags=["tags"], counter="cli_create_tags")
     args = ["create"]
     for t in tags:

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -56,7 +56,7 @@ def test_diff_equal(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -78,7 +78,7 @@ def test_diff_modified_file(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=101, stdout=f)
         f.seek(0)
@@ -104,7 +104,7 @@ def test_diff_symlink_target(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=101, stdout=f)
         f.seek(0)
@@ -130,7 +130,7 @@ def test_diff_wrong_type(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -156,7 +156,7 @@ def test_diff_missing_files(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -184,7 +184,7 @@ def test_diff_mult(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -212,12 +212,12 @@ def test_diff_metadata(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
         assert list(get_output(f)) == []
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", "--report-meta",
                 str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=100, stdout=f)
@@ -243,7 +243,7 @@ def test_diff_missing_dir(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -251,7 +251,7 @@ def test_diff_missing_dir(test_data, testname, monkeypatch, abspath):
         assert len(out) == 2
         assert out[0] == "Only in %s: %s" % (archive_ref_path, pd)
         assert out[1] == "Only in %s: %s" % (archive_ref_path, pd / "rnd_z.dat")
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", "--skip-dir-content",
                 str(archive_ref_path), str(archive_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
@@ -281,7 +281,7 @@ def test_diff_orphan_dir_content(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_b = Path(archive_name(ext="bz2", tags=[testname, "b", flag]))
     Archive().create(archive_b, "bz2", incl_b, excludes=excl_b)
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_a), str(archive_b)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -293,7 +293,7 @@ def test_diff_orphan_dir_content(test_data, testname, monkeypatch, abspath):
                           % (archive_a, pm, archive_b, pm))
         assert out[3] == "Only in %s: %s" % (archive_b, pd / "zz")
         assert out[4] == "Only in %s: %s" % (archive_b, pd / "zz" / "rnd_z.dat")
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", "--skip-dir-content", str(archive_a), str(archive_b)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)
@@ -317,7 +317,7 @@ def test_diff_extrafile_end(test_data, testname, monkeypatch, abspath):
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
-    with TemporaryFile(mode="w+t", dir=str(test_data)) as f:
+    with TemporaryFile(mode="w+t", dir=test_data) as f:
         args = ["diff", str(archive_path), str(archive_ref_path)]
         callscript("archive-tool.py", args, returncode=102, stdout=f)
         f.seek(0)

--- a/tests/test_04_cli_diff.py
+++ b/tests/test_04_cli_diff.py
@@ -37,7 +37,7 @@ def test_dir(tmpdir):
 
 @pytest.fixture(scope="function")
 def test_data(request, test_dir):
-    shutil.rmtree(str(test_dir / "base"), ignore_errors=True)
+    shutil.rmtree(test_dir / "base", ignore_errors=True)
     with Archive().open(test_dir / "archive-rel.tar") as archive:
         archive.extract(test_dir)
     return test_dir
@@ -46,7 +46,7 @@ def test_data(request, test_dir):
 def test_diff_equal(test_data, testname, monkeypatch, abspath):
     """Diff two archives having equal content.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -66,7 +66,7 @@ def test_diff_equal(test_data, testname, monkeypatch, abspath):
 def test_diff_modified_file(test_data, testname, monkeypatch, abspath):
     """Diff two archives having one file's content modified.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -74,7 +74,7 @@ def test_diff_modified_file(test_data, testname, monkeypatch, abspath):
         archive_ref_path = Path("archive-rel.tar")
         base_dir = Path("base")
     p = base_dir / "rnd.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(p))
+    shutil.copy(gettestdata("rnd2.dat"), p)
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
@@ -91,7 +91,7 @@ def test_diff_modified_file(test_data, testname, monkeypatch, abspath):
 def test_diff_symlink_target(test_data, testname, monkeypatch, abspath):
     """Diff two archives having one symlink's target modified.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -117,7 +117,7 @@ def test_diff_symlink_target(test_data, testname, monkeypatch, abspath):
 def test_diff_wrong_type(test_data, testname, monkeypatch, abspath):
     """Diff two archives with one entry having a wrong type.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -143,7 +143,7 @@ def test_diff_wrong_type(test_data, testname, monkeypatch, abspath):
 def test_diff_missing_files(test_data, testname, monkeypatch, abspath):
     """Diff two archives having one file's name changed.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -169,7 +169,7 @@ def test_diff_missing_files(test_data, testname, monkeypatch, abspath):
 def test_diff_mult(test_data, testname, monkeypatch, abspath):
     """Diff two archives having multiple differences.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -177,7 +177,7 @@ def test_diff_mult(test_data, testname, monkeypatch, abspath):
         archive_ref_path = Path("archive-rel.tar")
         base_dir = Path("base")
     pm = base_dir / "data" / "rnd.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(pm))
+    shutil.copy(gettestdata("rnd2.dat"), pm)
     p1 = base_dir / "msg.txt"
     p2 = base_dir / "o.txt"
     p1.rename(p2)
@@ -200,7 +200,7 @@ def test_diff_metadata(test_data, testname, monkeypatch, abspath):
     """Diff two archives having one file's file system metadata modified.
     This difference should be ignored by default.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -231,7 +231,7 @@ def test_diff_metadata(test_data, testname, monkeypatch, abspath):
 def test_diff_missing_dir(test_data, testname, monkeypatch, abspath):
     """Diff two archives with one subdirectory missing.
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -239,7 +239,7 @@ def test_diff_missing_dir(test_data, testname, monkeypatch, abspath):
         archive_ref_path = Path("archive-rel.tar")
         base_dir = Path("base")
     pd = base_dir / "data" / "zz"
-    shutil.rmtree(str(pd))
+    shutil.rmtree(pd)
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])
@@ -264,7 +264,7 @@ def test_diff_missing_dir(test_data, testname, monkeypatch, abspath):
 def test_diff_orphan_dir_content(test_data, testname, monkeypatch, abspath):
     """Diff archives having content in a missing directory.  Ref. #56
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         base_dir = test_data / "base"
     else:
@@ -275,7 +275,7 @@ def test_diff_orphan_dir_content(test_data, testname, monkeypatch, abspath):
     archive_a = Path(archive_name(ext="bz2", tags=[testname, "a", flag]))
     Archive().create(archive_a, "bz2", [base_dir], excludes=excl_a)
     pm = pd / "rnd2.dat"
-    shutil.copy(str(gettestdata("rnd.dat")), str(pm))
+    shutil.copy(gettestdata("rnd.dat"), pm)
     incl_b = [ base_dir, pd / "aa", pd / "rnd2.dat", pd / "zz" ]
     excl_b = [ pd, pd / "rnd.dat" ]
     flag = absflag(abspath)
@@ -305,7 +305,7 @@ def test_diff_orphan_dir_content(test_data, testname, monkeypatch, abspath):
 def test_diff_extrafile_end(test_data, testname, monkeypatch, abspath):
     """The first archives has an extra entry as last item.  Ref. #55
     """
-    monkeypatch.chdir(str(test_data))
+    monkeypatch.chdir(test_data)
     if abspath:
         archive_ref_path = Path("archive-abs.tar")
         base_dir = test_data / "base"
@@ -313,7 +313,7 @@ def test_diff_extrafile_end(test_data, testname, monkeypatch, abspath):
         archive_ref_path = Path("archive-rel.tar")
         base_dir = Path("base")
     p = base_dir / "zzz.dat"
-    shutil.copy(str(gettestdata("rnd2.dat")), str(p))
+    shutil.copy(gettestdata("rnd2.dat"), p)
     flag = absflag(abspath)
     archive_path = Path(archive_name(ext="bz2", tags=[testname, flag]))
     Archive().create(archive_path, "bz2", [base_dir])

--- a/tests/test_04_cli_error.py
+++ b/tests/test_04_cli_error.py
@@ -27,7 +27,7 @@ def test_dir(tmpdir):
     return tmpdir
 
 def test_cli_helpmessage(test_dir, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["-h"]
         callscript("archive-tool.py", args, stdout=f)
@@ -36,7 +36,7 @@ def test_cli_helpmessage(test_dir, monkeypatch):
         assert line.startswith("usage: archive-tool.py ")
 
 def test_cli_missing_command(test_dir, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = []
         callscript("archive-tool.py", args, returncode=2, stderr=f)
@@ -50,7 +50,7 @@ def test_cli_missing_command(test_dir, monkeypatch):
         assert "subcommand is required" in line
 
 def test_cli_bogus_command(test_dir, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["bogus_cmd"]
         callscript("archive-tool.py", args, returncode=2, stderr=f)
@@ -64,7 +64,7 @@ def test_cli_bogus_command(test_dir, monkeypatch):
         assert "invalid choice: 'bogus_cmd'" in line
 
 def test_cli_create_bogus_compression(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", "--compression=bogus_comp", name, "base"]
@@ -79,7 +79,7 @@ def test_cli_create_bogus_compression(test_dir, testname, monkeypatch):
         assert "--compression: invalid choice: 'bogus_comp'" in line
 
 def test_cli_ls_bogus_format(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
@@ -96,7 +96,7 @@ def test_cli_ls_bogus_format(test_dir, testname, monkeypatch):
         assert "--format: invalid choice: 'bogus_fmt'" in line
 
 def test_cli_create_normalized_path(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", name, "base/empty/.."]
@@ -106,7 +106,7 @@ def test_cli_create_normalized_path(test_dir, testname, monkeypatch):
         assert "invalid path 'base/empty/..': must be normalized" in line
 
 def test_cli_create_rel_start_basedir(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["create", "--basedir=base/data", name, "base/msg.txt"]
@@ -117,7 +117,7 @@ def test_cli_create_rel_start_basedir(test_dir, testname, monkeypatch):
                 "base directory base/data") in line
 
 def test_cli_ls_archive_not_found(test_dir, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
         args = ["ls", "bogus.tar"]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
@@ -126,7 +126,7 @@ def test_cli_ls_archive_not_found(test_dir, monkeypatch):
         assert "No such file or directory: 'bogus.tar'" in line
 
 def test_cli_ls_checksum_invalid_hash(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
@@ -138,7 +138,7 @@ def test_cli_ls_checksum_invalid_hash(test_dir, testname, monkeypatch):
         assert "'bogus' hashes not available" in line
 
 def test_cli_info_missing_entry(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
@@ -150,7 +150,7 @@ def test_cli_info_missing_entry(test_dir, testname, monkeypatch):
         assert "base/data/not-present: not found in archive" in line
 
 def test_cli_integrity_no_manifest(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     with tarfile.open(name, "w") as tarf:
         tarf.add("base", recursive=True)
@@ -162,7 +162,7 @@ def test_cli_integrity_no_manifest(test_dir, testname, monkeypatch):
         assert "metadata item '.manifest.yaml' not found" in line
 
 def test_cli_integrity_missing_file(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     base = Path("base")
     missing = base / "data" / "not-present"
@@ -171,9 +171,9 @@ def test_cli_integrity_missing_file(test_dir, testname, monkeypatch):
     manifest = Manifest(paths=[base])
     with open("manifest.yaml", "wb") as f:
         manifest.write(f)
-    mtime_parent = os.stat(str(missing.parent)).st_mtime
+    mtime_parent = os.stat(missing.parent).st_mtime
     missing.unlink()
-    os.utime(str(missing.parent), times=(mtime_parent, mtime_parent))
+    os.utime(missing.parent, times=(mtime_parent, mtime_parent))
     with tarfile.open(name, "w") as tarf:
         with open("manifest.yaml", "rb") as f:
             manifest_info = tarf.gettarinfo(arcname="base/.manifest.yaml", 
@@ -189,7 +189,7 @@ def test_cli_integrity_missing_file(test_dir, testname, monkeypatch):
         assert "%s:%s: missing" % (name, missing) in line
 
 def test_cli_check_stdin_and_files(test_dir, testname, monkeypatch):
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)

--- a/tests/test_04_cli_error.py
+++ b/tests/test_04_cli_error.py
@@ -28,7 +28,7 @@ def test_dir(tmpdir):
 
 def test_cli_helpmessage(test_dir, monkeypatch):
     monkeypatch.chdir(test_dir)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["-h"]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -37,7 +37,7 @@ def test_cli_helpmessage(test_dir, monkeypatch):
 
 def test_cli_missing_command(test_dir, monkeypatch):
     monkeypatch.chdir(test_dir)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = []
         callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
@@ -51,7 +51,7 @@ def test_cli_missing_command(test_dir, monkeypatch):
 
 def test_cli_bogus_command(test_dir, monkeypatch):
     monkeypatch.chdir(test_dir)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["bogus_cmd"]
         callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
@@ -66,7 +66,7 @@ def test_cli_bogus_command(test_dir, monkeypatch):
 def test_cli_create_bogus_compression(test_dir, testname, monkeypatch):
     monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["create", "--compression=bogus_comp", name, "base"]
         callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
@@ -83,7 +83,7 @@ def test_cli_ls_bogus_format(test_dir, testname, monkeypatch):
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", "--format=bogus_fmt", name]
         callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)
@@ -98,7 +98,7 @@ def test_cli_ls_bogus_format(test_dir, testname, monkeypatch):
 def test_cli_create_normalized_path(test_dir, testname, monkeypatch):
     monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["create", name, "base/empty/.."]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
@@ -108,7 +108,7 @@ def test_cli_create_normalized_path(test_dir, testname, monkeypatch):
 def test_cli_create_rel_start_basedir(test_dir, testname, monkeypatch):
     monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["create", "--basedir=base/data", name, "base/msg.txt"]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
@@ -118,7 +118,7 @@ def test_cli_create_rel_start_basedir(test_dir, testname, monkeypatch):
 
 def test_cli_ls_archive_not_found(test_dir, monkeypatch):
     monkeypatch.chdir(test_dir)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", "bogus.tar"]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
@@ -130,7 +130,7 @@ def test_cli_ls_checksum_invalid_hash(test_dir, testname, monkeypatch):
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", "--format=checksum", "--checksum=bogus", name]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
@@ -142,7 +142,7 @@ def test_cli_info_missing_entry(test_dir, testname, monkeypatch):
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["info", name, "base/data/not-present"]
         callscript("archive-tool.py", args, returncode=1, stderr=f)
         f.seek(0)
@@ -154,7 +154,7 @@ def test_cli_integrity_no_manifest(test_dir, testname, monkeypatch):
     name = archive_name(tags=[testname])
     with tarfile.open(name, "w") as tarf:
         tarf.add("base", recursive=True)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["ls", name]
         callscript("archive-tool.py", args, returncode=3, stderr=f)
         f.seek(0)
@@ -181,7 +181,7 @@ def test_cli_integrity_missing_file(test_dir, testname, monkeypatch):
             manifest_info.mode = stat.S_IFREG | 0o444
             tarf.addfile(manifest_info, f)
         tarf.add("base")
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["verify", name]
         callscript("archive-tool.py", args, returncode=3, stderr=f)
         f.seek(0)
@@ -193,7 +193,7 @@ def test_cli_check_stdin_and_files(test_dir, testname, monkeypatch):
     name = archive_name(tags=[testname])
     args = ["create", name, "base"]
     callscript("archive-tool.py", args)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["check", "--stdin", name, "base"]
         callscript("archive-tool.py", args, returncode=2, stderr=f)
         f.seek(0)

--- a/tests/test_04_cli_find.py
+++ b/tests/test_04_cli_find.py
@@ -68,7 +68,7 @@ def test_find_all(test_dir, abspath):
     Expect the call to list all entries from the archives.
     """
     archives = archive_paths(test_dir, abspath)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find"] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -88,7 +88,7 @@ def test_find_bytype(test_dir, abspath, type):
     """Call archive-tool to find entries by type.
     """
     archives = archive_paths(test_dir, abspath)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--type", type] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -111,7 +111,7 @@ def test_find_byname_exact(test_dir, abspath):
     """Call archive-tool to find entries by exact name.
     """
     archives = archive_paths(test_dir, abspath)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--name", "rnd.dat"] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -135,7 +135,7 @@ def test_find_byname_wildcard(test_dir, pattern, abspath):
     """Call archive-tool to find entries with matching name.
     """
     archives = archive_paths(test_dir, abspath)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--name", pattern] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -173,7 +173,7 @@ def test_find_bymtime_rel(test_dir, mtime, delta):
         elif direct == '-':
             return entry.mtime is None or entry.mtime > timestamp
     archives = archive_paths(test_dir, False)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--mtime=%s" % mtime] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -204,7 +204,7 @@ def test_find_bymtime_abs(test_dir, mtime, dt):
         elif direct == '>':
             return entry.mtime is None or entry.mtime > timestamp
     archives = archive_paths(test_dir, False)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--mtime=%s" % mtime] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)
@@ -238,7 +238,7 @@ def test_find_bymtime_abs_datefmt(test_dir, mtime, dt):
         elif direct == '>':
             return entry.mtime is None or entry.mtime > timestamp
     archives = archive_paths(test_dir, False)
-    with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
         args = ["find", "--mtime=%s" % mtime] + [str(p) for p in archives]
         callscript("archive-tool.py", args, stdout=f)
         f.seek(0)

--- a/tests/test_04_cli_find.py
+++ b/tests/test_04_cli_find.py
@@ -59,7 +59,7 @@ def test_dir(tmpdir):
             setup_testdata(tmpdir, data)
             Archive().create(rel_paths[i], "bz2", [base])
             Archive().create(abs_paths[i], "bz2", [tmpdir / base])
-            shutil.rmtree(str(base))
+            shutil.rmtree(base)
     return tmpdir
 
 @pytest.mark.parametrize("abspath", [False, True])

--- a/tests/test_04_cli_warn.py
+++ b/tests/test_04_cli_warn.py
@@ -49,7 +49,7 @@ def test_cli_warn_ignore_socket(test_dir, testname, monkeypatch):
     basedir = Path("base")
     fp = basedir / "socket"
     with tmp_socket(fp):
-        with TemporaryFile(mode="w+t", dir=str(test_dir)) as f:
+        with TemporaryFile(mode="w+t", dir=test_dir) as f:
             args = ["create", name, "base"]
             callscript("archive-tool.py", args, stderr=f)
             f.seek(0)

--- a/tests/test_04_cli_warn.py
+++ b/tests/test_04_cli_warn.py
@@ -44,7 +44,7 @@ def test_cli_warn_ignore_socket(test_dir, testname, monkeypatch):
     archive-tool.py should issue a warning that the socket has been
     ignored, but otherwise proceed to create the archive.
     """
-    monkeypatch.chdir(str(test_dir))
+    monkeypatch.chdir(test_dir)
     name = archive_name(tags=[testname])
     basedir = Path("base")
     fp = basedir / "socket"

--- a/tests/test_05_mailarchive_create.py
+++ b/tests/test_05_mailarchive_create.py
@@ -42,7 +42,7 @@ def test_create_mailarchive(tmpdir, monkeypatch, testcase):
     if testcase == "abs":
         archive_path = tmpdir / "mailarchive-abs.tar.xz"
     else:
-        monkeypatch.chdir(str(tmpdir))
+        monkeypatch.chdir(tmpdir)
         archive_path = "mailarchive-rel.tar.xz"
     archive = MailArchive()
     archive.create(archive_path, getmsgs(), server="imap.example.org")


### PR DESCRIPTION
Require Python 3.6 or newer.  Drop support for older versions.