### PR TITLE
Explicitely select POSIX.1-2001 (pax) format in the tarfile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ New features
 + `#50`_, `#51`_: Add a header with some metadata to the index in a
   mail archive created by :class:`MailArchive`.
 
++ `#62`_, `#63`_: Explicitely select POSIX.1-2001 (pax) format in the
+  tarfile.  This fixes failing verification if the archive contains a
+  directory with a long path name.
+
 Incompatible changes
 --------------------
 
@@ -74,6 +78,8 @@ Bug fixes and minor changes
 .. _#59: https://github.com/RKrahl/archive-tools/pull/59
 .. _#60: https://github.com/RKrahl/archive-tools/pull/60
 .. _#61: https://github.com/RKrahl/archive-tools/pull/61
+.. _#62: https://github.com/RKrahl/archive-tools/issues/62
+.. _#63: https://github.com/RKrahl/archive-tools/pull/63
 
 
 0.5.1 (2020-12-12)

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -117,7 +117,7 @@ class Archive:
         return self
 
     def _create(self, mode):
-        with tarfile.open(self.path, mode) as tarf:
+        with tarfile.open(self.path, mode, format=tarfile.PAX_FORMAT) as tarf:
             with tempfile.TemporaryFile() as tmpf:
                 self.manifest.write(tmpf)
                 tmpf.seek(0)

--- a/tests/test_03_create_misc.py
+++ b/tests/test_03_create_misc.py
@@ -2,11 +2,9 @@
 """
 
 from pathlib import Path
-import sys
 from tempfile import TemporaryFile
 import pytest
 from archive import Archive
-from archive.exception import ArchiveIntegrityError
 from conftest import *
 
 
@@ -125,8 +123,6 @@ def test_create_tags(test_dir, monkeypatch, tags, expected):
     with Archive().open(archive_path) as archive:
         assert archive.manifest.tags == expected
 
-@pytest.mark.xfail(sys.version_info < (3, 8),
-                   reason="Issue #62", raises=ArchiveIntegrityError)
 def test_create_long_directory_name(tmpdir, monkeypatch):
     """An archive containing a directory with a long path name.
 


### PR DESCRIPTION
Explicitely select POSIX.1-2001 (pax) format in the tarfile.  This fixes #62.