### PR TITLE
Add a method Archiv.extract_member()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ Bug fixes and minor changes
   optional.  The default will be derived from the suffixes of the
   `path` argument.
 
++ `#65`_: Add a method :meth:`Archive.extract_member` to extract an
+  individual member of the archive.
+
 + `#53`_, `#54`_: Spurious :exc:`FileNotFoundError` from
   :meth:`Archive.create` when passing a relative path as `workdir`
   argument.
@@ -63,6 +66,9 @@ Bug fixes and minor changes
 
 + `#56`_, `#57`_: Inconsistent result from `archive-tool diff` with
   option `--skip-dir-content`.
+
++ `#64`_, `#65`_: :meth:`Archive.extract` does not preserve the file
+  modification time for symbol links.
 
 + `#48`_: Review and standardize some error messages.
 
@@ -80,6 +86,8 @@ Bug fixes and minor changes
 .. _#61: https://github.com/RKrahl/archive-tools/pull/61
 .. _#62: https://github.com/RKrahl/archive-tools/issues/62
 .. _#63: https://github.com/RKrahl/archive-tools/pull/63
+.. _#64: https://github.com/RKrahl/archive-tools/issues/64
+.. _#65: https://github.com/RKrahl/archive-tools/pull/65
 
 
 0.5.1 (2020-12-12)

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -327,6 +327,10 @@ class Archive:
         else:
             raise ArchiveIntegrityError("%s: invalid type" % (itemname))
 
+    def extract_member(self, fi, targetdir):
+        arcname = self._arcname(fi.path)
+        self._file.extract(arcname, path=str(targetdir))
+
     def extract(self, targetdir, inclmeta=False):
         # We extract the directories last in reverse order.  This way,
         # the directory attributes, in particular the file modification
@@ -338,12 +342,12 @@ class Archive:
                 self._file.extract(mi, path=str(targetdir))
         for fi in self.manifest:
             if fi.is_dir():
-                dirstack.append(fi.path)
+                dirstack.append(fi)
             else:
-                self._file.extract(self._arcname(fi.path), path=str(targetdir))
+                self.extract_member(fi, targetdir)
         while True:
             try:
-                p = dirstack.pop()
+                fi = dirstack.pop()
             except IndexError:
                 break
-            self._file.extract(self._arcname(p), path=str(targetdir))
+            self.extract_member(fi, targetdir)

--- a/archive/archive.py
+++ b/archive/archive.py
@@ -329,7 +329,9 @@ class Archive:
 
     def extract_member(self, fi, targetdir):
         arcname = self._arcname(fi.path)
+        mtimes = (fi.mtime, fi.mtime)
         self._file.extract(arcname, path=str(targetdir))
+        os.utime(targetdir / arcname, mtimes, follow_symlinks=False)
 
     def extract(self, targetdir, inclmeta=False):
         # We extract the directories last in reverse order.  This way,

--- a/tests/test_02_create.py
+++ b/tests/test_02_create.py
@@ -4,11 +4,13 @@
 import datetime
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import pytest
 from pytest_dependency import depends
 from archive import Archive
 from archive.manifest import FileInfo, Manifest
+from archive.tools import mode_ft
 from conftest import *
 
 
@@ -112,6 +114,29 @@ def test_check_content(test_dir, dep_testcase, inclmeta):
     sha256.stdin.close()
     sha256.wait()
     assert sha256.returncode == 0
+
+@pytest.mark.xfail(reason="Issue #64")
+@pytest.mark.dependency()
+def test_check_fstat(test_dir, dep_testcase):
+    """Check that file system metadata are preserved
+    """
+    compression, abspath = dep_testcase
+    flag = absflag(abspath)
+    archive_path = test_dir / archive_name(ext=compression, tags=[flag])
+    outdir = test_dir / "out"
+    shutil.rmtree(outdir, ignore_errors=True)
+    outdir.mkdir()
+    if abspath:
+        cwd = outdir / "archive" / test_dir.relative_to(test_dir.anchor)
+    else:
+        cwd = outdir
+    with Archive().open(archive_path) as archive:
+        archive.extract(outdir)
+    for f in testdata:
+        fstat = (cwd / f.path).lstat()
+        assert mode_ft[stat.S_IFMT(fstat.st_mode)] == f.type
+        assert fstat.st_mtime == f.mtime
+        assert stat.S_IMODE(fstat.st_mode) == f.mode
 
 @pytest.mark.dependency()
 def test_verify(test_dir, dep_testcase):

--- a/tests/test_02_create.py
+++ b/tests/test_02_create.py
@@ -115,7 +115,6 @@ def test_check_content(test_dir, dep_testcase, inclmeta):
     sha256.wait()
     assert sha256.returncode == 0
 
-@pytest.mark.xfail(reason="Issue #64")
 @pytest.mark.dependency()
 def test_check_fstat(test_dir, dep_testcase):
     """Check that file system metadata are preserved


### PR DESCRIPTION
- Add a method `Archiv.extract_member()` to extract an individual member of the archive.
- Fix #64.