### PR TITLE
Also report differences in file system metadata for directories and symbol links diff_manifest()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features
 + `#54`_: Add new keyword argument `fileinfos` that :class:`Manifest`
   and :meth:`Archive.create` accept.
 
-+ `#57`_: Add :func:`diff_manifest`.
++ `#57`_, `#66`_: Add :func:`diff_manifest`.  The `archive-tool diff`
+  command with `--report-meta` flag also reports differences in file
+  system metadata for directories and symbol links.
 
 + `#50`_, `#51`_: Add a header with some metadata to the index in a
   mail archive created by :class:`MailArchive`.
@@ -88,6 +90,7 @@ Bug fixes and minor changes
 .. _#63: https://github.com/RKrahl/archive-tools/pull/63
 .. _#64: https://github.com/RKrahl/archive-tools/issues/64
 .. _#65: https://github.com/RKrahl/archive-tools/pull/65
+.. _#66: https://github.com/RKrahl/archive-tools/pull/66
 
 
 0.5.1 (2020-12-12)

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -289,18 +289,14 @@ def diff_manifest(manifest_a, manifest_b, checksum=FileInfo.Checksums[0]):
             if fi_a.target != fi_b.target:
                 return DiffStatus.SYMLNK_TARGET
         elif fi_a.type == "f":
-            # Note: we don't need to compare the size, because if
-            # the size differs, it's mostly certain that also the
-            # checksum do.
-            if fi_a.checksum[algorithm] != fi_b.checksum[algorithm]:
+            if (fi_a.size != fi_b.size or
+                fi_a.checksum[algorithm] != fi_b.checksum[algorithm]):
                 return DiffStatus.CONTENT
-            elif (fi_a.uid != fi_b.uid or
-                  fi_a.uname != fi_b.uname or
-                  fi_a.gid != fi_b.gid or
-                  fi_a.gname != fi_b.gname or
-                  fi_a.mode != fi_b.mode or
-                  int(fi_a.mtime) != int(fi_b.mtime)):
-                return DiffStatus.META
+        if (fi_a.uid != fi_b.uid or fi_a.uname != fi_b.uname or
+            fi_a.gid != fi_b.gid or fi_a.gname != fi_b.gname or
+            fi_a.mode != fi_b.mode or
+            int(fi_a.mtime) != int(fi_b.mtime)):
+            return DiffStatus.META
         return DiffStatus.MATCH
 
     it_a = iter(itertools.chain(manifest_a, itertools.repeat(None)))

--- a/tests/test_02_diff_manifest.py
+++ b/tests/test_02_diff_manifest.py
@@ -1,6 +1,7 @@
 """Test diff_manifest() function in archive.manifest.
 """
 
+import os
 from pathlib import Path
 import shutil
 from tempfile import TemporaryFile
@@ -77,8 +78,10 @@ def test_diff_manifest_modified_file(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     p = base_dir / "rnd.dat"
     shutil.copy(gettestdata("rnd2.dat"), p)
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1
@@ -94,9 +97,11 @@ def test_diff_manifest_symlink_target(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     p = base_dir / "s.dat"
     p.unlink()
     p.symlink_to(Path("msg.txt"))
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1
@@ -112,9 +117,11 @@ def test_diff_manifest_wrong_type(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     p = base_dir / "rnd.dat"
     p.unlink()
     p.symlink_to(Path("data", "rnd.dat"))
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1
@@ -131,9 +138,11 @@ def test_diff_manifest_missing_files(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     p1 = base_dir / "rnd.dat"
     p2 = base_dir / "a.dat"
     p1.rename(p2)
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 2
@@ -155,11 +164,15 @@ def test_diff_manifest_mult(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
+    mtime_data = os.stat(base_dir / "data").st_mtime
     pm = base_dir / "data" / "rnd.dat"
     shutil.copy(gettestdata("rnd2.dat"), pm)
     p1 = base_dir / "msg.txt"
     p2 = base_dir / "o.txt"
     p1.rename(p2)
+    os.utime(base_dir, times=(mtime_base, mtime_base))
+    os.utime(base_dir / "data", times=(mtime_data, mtime_data))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 3
@@ -185,8 +198,10 @@ def test_diff_manifest_dircontent(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     pd = base_dir / "data"
     shutil.rmtree(pd)
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 2
@@ -211,8 +226,10 @@ def test_diff_manifest_add_file_last(test_data, testname, monkeypatch):
     with Archive().open(Path("archive.tar")) as archive:
         manifest_ref = archive.manifest
     base_dir = Path("base")
+    mtime_base = os.stat(base_dir).st_mtime
     p = base_dir / "zzz.dat"
     shutil.copy(gettestdata("rnd2.dat"), p)
+    os.utime(base_dir, times=(mtime_base, mtime_base))
     fileinfos = get_fileinfos(base_dir)
     diff = list(filter(non_match, diff_manifest(fileinfos, manifest_ref)))
     assert len(diff) == 1


### PR DESCRIPTION
Change the function `diff_manifest()` to also report differences in file system metadata for directories and symbol links.  This also affects the output of the `archive-tool diff` command if the `--report-meta` flag is given.