### PR TITLE
Review build tool chain

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,6 +11,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12.0-beta - 3.12.0'
         os: [ubuntu-latest]
         include:
           - python-version: '3.6'

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 *~
 __pycache__/
 /.env
-/.version
 /MANIFEST
+/_meta.py
 /archive/__init__.py
 /build/
 /dist/
-/tests/.cache/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,17 @@ Changelog
 =========
 
 
+0.7 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Internal changes
+----------------
+
++ `#74`_: Review build tool chain.
+
+.. _#74: https://github.com/RKrahl/archive-tools/pull/74
+
+
 0.6 (2021-12-12)
 ~~~~~~~~~~~~~~~~
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include .version
 include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst
+include _meta.py
 include tests/conftest.py
 include tests/data/.sha256
 include tests/data/legacy-1_0.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,17 @@ sdist:
 	$(PYTHON) setup.py sdist
 
 clean:
-	rm -f *~ archive/*~ archive/bt/*~ archive/cli/*~ scripts/*~ tests/*~
 	rm -rf build
+	rm -rf __pycache__
 
 distclean: clean
-	rm -rf archive/__pycache__ \
-	    archive/bt/__pycache__ archive/cli/__pycache__ \
-	    scripts/__pycache__ tests/__pycache__
-	rm -rf tests/.cache tests/.pytest_cache
-	rm -f MANIFEST .version
+	rm -f MANIFEST _meta.py
 	rm -f archive/__init__.py
 	rm -rf dist
+	rm -rf tests/.pytest_cache
+
+meta:
+	$(PYTHON) setup.py meta
 
 
-.PHONY: build test sdist clean distclean
+.PHONY: build test sdist clean distclean meta

--- a/README.rst
+++ b/README.rst
@@ -99,39 +99,13 @@ Optional library packages:
   Only needed to run the test suite.
 
 
-Installation
-------------
-
-This package uses the distutils Python standard library package and
-follows its conventions of packaging source distributions.  See the
-documentation on `Installing Python Modules`_ for details or to
-customize the install process.
-
-1. Download the sources, unpack, and change into the source directory.
-
-2. Build::
-
-     $ python setup.py build
-
-3. Test (optional)::
-
-     $ python setup.py test
-
-4. Install::
-
-     $ python setup.py install
-
-The last step might require admin privileges in order to write into
-the site-packages directory of your Python installation.
-
-
 Copyright and License
 ---------------------
 
-Copyright 2019–2021 Rolf Krahl
+Copyright 2019–2023 Rolf Krahl
 
 Licensed under the `Apache License`_, Version 2.0 (the "License"); you
-may not use this file except in compliance with the License.
+may not use this package except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -142,13 +116,12 @@ permissions and limitations under the License.
 
 .. _setuptools: https://github.com/pypa/setuptools/
 .. _PyPI site: https://pypi.org/project/archive-tools/
-.. _PyYAML: http://pyyaml.org/wiki/PyYAML
+.. _PyYAML: https://pypi.org/project/PyYAML/
 .. _lark-parser: https://github.com/lark-parser/lark
 .. _imapclient: https://github.com/mjs/imapclient/
 .. _python-dateutil: https://dateutil.readthedocs.io/en/stable/
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm/
-.. _pytest: http://pytest.org/
+.. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
 .. _pytest-dependency: https://pypi.python.org/pypi/pytest_dependency/
-.. _Installing Python Modules: https://docs.python.org/3.7/install/
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,8 @@ Python:
 
 Required library packages:
 
++ `setuptools`_
+
 + `PyYAML`_
 
 + `lark-parser`_
@@ -138,6 +140,7 @@ implied.  See the License for the specific language governing
 permissions and limitations under the License.
 
 
+.. _setuptools: https://github.com/pypa/setuptools/
 .. _PyPI site: https://pypi.org/project/archive-tools/
 .. _PyYAML: http://pyyaml.org/wiki/PyYAML
 .. _lark-parser: https://github.com/lark-parser/lark

--- a/python-archive-tools.spec
+++ b/python-archive-tools.spec
@@ -11,6 +11,7 @@ Group:		Development/Libraries/Python
 Source:		%{distname}-%{version}.tar.gz
 BuildRequires:	fdupes
 BuildRequires:	python3-base >= 3.6
+BuildRequires:	python3-setuptools
 %if %{with tests}
 BuildRequires:	python3-PyYAML
 BuildRequires:	python3-lark-parser

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: System :: Archiving",
         ],
     cmdclass = dict(cmdclass, build_py=build_py, init_py=init_py, sdist=sdist),

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ from the embedded metadata.  Retrieving this metadata does not require
 reading through the compressed tar archive.
 """
 
-import distutils.command.build_py
+import setuptools
+from setuptools import setup
+import setuptools.command.build_py
 import distutils.command.sdist
-import distutils.core
-from distutils.core import setup
-import distutils.log
+from distutils import log
 from glob import glob
 from pathlib import Path
 import string
@@ -42,87 +42,97 @@ except (ImportError, AttributeError):
 try:
     import setuptools_scm
     version = setuptools_scm.get_version()
-    with open(".version", "wt") as f:
-        f.write(version)
 except (ImportError, LookupError):
     try:
-        with open(".version", "rt") as f:
-            version = f.read()
-    except OSError:
-        distutils.log.warn("warning: cannot determine version number")
+        import _meta
+        version = _meta.__version__
+    except ImportError:
+        log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
 
-doclines = __doc__.strip().split("\n")
+docstring = __doc__
 
 
-class init_py(distutils.core.Command):
+class meta(setuptools.Command):
 
-    description = "generate the main __init__.py file"
+    description = "generate meta files"
     user_options = []
-    init_template = '''"""%s"""
+    init_template = '''"""%(doc)s"""
 
-__version__ = "%s"
+__version__ = "%(version)s"
 
 from archive.archive import Archive
 from archive.exception import *
 '''
+    meta_template = '''
+__version__ = "%(version)s"
+'''
 
     def initialize_options(self):
-        self.packages = None
         self.package_dir = None
 
     def finalize_options(self):
-        self.packages = self.distribution.packages
         self.package_dir = {}
         if self.distribution.package_dir:
             for name, path in self.distribution.package_dir.items():
                 self.package_dir[name] = convert_path(path)
 
     def run(self):
-        pkgname = "archive"
-        if pkgname not in self.packages:
-            raise DistutilsSetupError("Expected package '%s' not found"
-                                      % pkgname)
-        pkgdir = Path(self.package_dir.get(pkgname, pkgname))
-        ver = self.distribution.get_version()
-        with (pkgdir / "__init__.py").open("wt") as f:
-            print(self.init_template % (__doc__, ver), file=f)
+        values = {
+            'version': self.distribution.get_version(),
+            'doc': docstring
+        }
+        try:
+            pkgname = self.distribution.packages[0]
+        except IndexError:
+            log.warn("warning: no package defined")
+        else:
+            pkgdir = Path(self.package_dir.get(pkgname, pkgname))
+            if not pkgdir.is_dir():
+                pkgdir.mkdir()
+            with (pkgdir / "__init__.py").open("wt") as f:
+                print(self.init_template % values, file=f)
+        with Path("_meta.py").open("wt") as f:
+            print(self.meta_template % values, file=f)
 
 
+# Note: Do not use setuptools for making the source distribution,
+# rather use the good old distutils instead.
+# Rationale: https://rhodesmill.org/brandon/2009/eby-magic/
 class sdist(distutils.command.sdist.sdist):
     def run(self):
-        self.run_command('init_py')
+        self.run_command('meta')
         super().run()
         subst = {
             "version": self.distribution.get_version(),
             "url": self.distribution.get_url(),
-            "description": self.distribution.get_description(),
-            "long_description": self.distribution.get_long_description(),
+            "description": docstring.split("\n")[0],
+            "long_description": docstring.split("\n", maxsplit=2)[2].strip(),
         }
         for spec in glob("*.spec"):
             with Path(spec).open('rt') as inf:
                 with Path(self.dist_dir, spec).open('wt') as outf:
                     outf.write(string.Template(inf.read()).substitute(subst))
 
-class build_py(distutils.command.build_py.build_py):
+
+class build_py(setuptools.command.build_py.build_py):
     def run(self):
-        self.run_command('init_py')
+        self.run_command('meta')
         super().run()
+
+
+with Path("README.rst").open("rt", encoding="utf8") as f:
+    readme = f.read()
 
 setup(
     name = "archive-tools",
     version = version,
-    description = doclines[0],
-    long_description = "\n".join(doclines[2:]),
+    description = docstring.split("\n")[0],
+    long_description = readme,
+    url = "https://github.com/RKrahl/archive-tools",
     author = "Rolf Krahl",
     author_email = "rolf@rotkraut.de",
-    url = "https://github.com/RKrahl/archive-tools",
     license = "Apache-2.0",
-    requires = ["yaml", "lark"],
-    packages = ["archive", "archive.cli", "archive.bt"],
-    scripts = ["scripts/archive-tool.py", "scripts/backup-tool.py",
-               "scripts/imap-to-archive.py"],
-    data_files = [("/etc", ["etc/backup.cfg"])],
     classifiers = [
         "Development Status :: 4 - Beta",
         "Intended Audience :: System Administrators",
@@ -137,6 +147,12 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Topic :: System :: Archiving",
-        ],
-    cmdclass = dict(cmdclass, build_py=build_py, init_py=init_py, sdist=sdist),
+    ],
+    packages = ["archive", "archive.cli", "archive.bt"],
+    python_requires = ">=3.6",
+    install_requires = ["PyYAML", "lark"],
+    scripts = ["scripts/archive-tool.py", "scripts/backup-tool.py",
+               "scripts/imap-to-archive.py"],
+    data_files = [("/etc", ["etc/backup.cfg"])],
+    cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),
 )


### PR DESCRIPTION
Review tool chain to build the package:

- switch from `distutils` to `setuptools` in `setup.py` where appropriate,
- generate a `_meta` module to store the version number,
- misc review.
