### PR TITLE
Drop deprecated distutils.version.StrictVersion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,23 @@ Changelog
 0.7 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Bug fixes and minor changes
+---------------------------
+
++ `#75`_: Drop :class:`distutils.version.StrictVersion` deprecated
+  since Python 3.10 in favour of our own helper
+  :class:`archive.tools.Version` based on
+  :class:`packaging.version.Version`.  This adds a dependency on
+  :mod:`packaging`.
+
+
 Internal changes
 ----------------
 
 + `#74`_: Review build tool chain.
 
 .. _#74: https://github.com/RKrahl/archive-tools/pull/74
+.. _#75: https://github.com/RKrahl/archive-tools/pull/75
 
 
 0.6 (2021-12-12)

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ Required library packages:
 
 + `PyYAML`_
 
++ `packaging`_
+
 + `lark-parser`_
 
   Required for the `backup-tool.py` script.
@@ -117,6 +119,7 @@ permissions and limitations under the License.
 .. _setuptools: https://github.com/pypa/setuptools/
 .. _PyPI site: https://pypi.org/project/archive-tools/
 .. _PyYAML: https://pypi.org/project/PyYAML/
+.. _packaging: https://github.com/pypa/packaging/
 .. _lark-parser: https://github.com/lark-parser/lark
 .. _imapclient: https://github.com/mjs/imapclient/
 .. _python-dateutil: https://dateutil.readthedocs.io/en/stable/

--- a/archive/index.py
+++ b/archive/index.py
@@ -2,11 +2,10 @@
 """
 
 from collections.abc import Mapping, Sequence
-from distutils.version import StrictVersion
 from pathlib import Path
 import yaml
 from archive.archive import Archive
-from archive.tools import parse_date
+from archive.tools import Version, parse_date
 
 
 class IndexItem:
@@ -106,7 +105,7 @@ class ArchiveIndex(Sequence):
 
     @property
     def version(self):
-        return StrictVersion(self.head["Version"])
+        return Version(self.head["Version"])
 
     def find(self, path):
         for i in self:

--- a/archive/mailarchive.py
+++ b/archive/mailarchive.py
@@ -1,11 +1,10 @@
-from distutils.version import StrictVersion
 import hashlib
 from mailbox import Maildir
 from pathlib import Path
 from tempfile import TemporaryDirectory, TemporaryFile
 import yaml
 from archive import Archive
-from archive.tools import now_str, parse_date, tmp_chdir, tmp_umask
+from archive.tools import Version, now_str, parse_date, tmp_chdir, tmp_umask
 
 
 class MailIndex(list):
@@ -37,7 +36,7 @@ class MailIndex(list):
 
     @property
     def version(self):
-        return StrictVersion(self.head["Version"])
+        return Version(self.head["Version"])
 
     @property
     def date(self):

--- a/archive/manifest.py
+++ b/archive/manifest.py
@@ -3,7 +3,6 @@
 
 from collections.abc import Sequence
 import datetime
-from distutils.version import StrictVersion
 from enum import Enum
 import grp
 import itertools
@@ -15,7 +14,8 @@ import warnings
 import yaml
 import archive
 from archive.exception import ArchiveInvalidTypeError, ArchiveWarning
-from archive.tools import now_str, parse_date, checksum, mode_ft, ft_mode
+from archive.tools import (Version, now_str, parse_date,
+                           checksum, mode_ft, ft_mode)
 
 
 class DiffStatus(Enum):
@@ -201,7 +201,7 @@ class Manifest(Sequence):
 
     @property
     def version(self):
-        return StrictVersion(self.head["Version"])
+        return Version(self.head["Version"])
 
     @property
     def date(self):

--- a/archive/tools.py
+++ b/archive/tools.py
@@ -18,6 +18,7 @@ try:
     from dateutil.parser import parse as _dateutil_parse
 except ImportError:
     _dateutil_parse = None
+import packaging.version
 
 
 if hasattr(datetime.datetime, 'fromisoformat'):
@@ -46,6 +47,50 @@ else:
             return datetime.datetime(*dt, tzinfo=tz)
         else:
             raise ValueError("Invalid isoformat string: '%s'" % date_string)
+
+
+class Version(packaging.version.Version):
+    """A variant of packaging.version.Version.
+
+    This version adds comparison with strings.
+
+    >>> version = Version('4.11.1')
+    >>> version == '4.11.1'
+    True
+    >>> version < '4.9.3'
+    False
+    >>> version = Version('5.0.0a1')
+    >>> version > '4.11.1'
+    True
+    >>> version < '5.0.0'
+    True
+    >>> version == '5.0.0a1'
+    True
+    """
+    def __lt__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__lt__(other)
+    def __le__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__le__(other)
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__eq__(other)
+    def __ge__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__ge__(other)
+    def __gt__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__gt__(other)
+    def __ne__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__ne__(other)
 
 
 class tmp_chdir():

--- a/python-archive-tools.spec
+++ b/python-archive-tools.spec
@@ -16,11 +16,13 @@ BuildRequires:	python3-setuptools
 BuildRequires:	python3-PyYAML
 BuildRequires:	python3-lark-parser
 BuildRequires:	python3-distutils-pytest
+BuildRequires:	python3-packaging
 BuildRequires:	python3-pytest-dependency >= 0.2
 BuildRequires:	python3-pytest >= 3.0
 %endif
 Requires:	python3-PyYAML
 Requires:	python3-lark-parser
+Requires:	python3-packaging
 Recommends:	python3-IMAPClient
 Recommends:	python3-python-dateutil
 BuildArch:	noarch

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     ],
     packages = ["archive", "archive.cli", "archive.bt"],
     python_requires = ">=3.6",
-    install_requires = ["PyYAML", "lark"],
+    install_requires = ["PyYAML", "packaging", "lark"],
     scripts = ["scripts/archive-tool.py", "scripts/backup-tool.py",
                "scripts/imap-to-archive.py"],
     data_files = [("/etc", ["etc/backup.cfg"])],

--- a/tests/test_01_tools.py
+++ b/tests/test_01_tools.py
@@ -1,0 +1,32 @@
+"""Test module archive.tools
+"""
+
+import packaging.version
+import pytest
+from archive.tools import *
+
+@pytest.mark.parametrize(("vstr", "checks"), [
+    ("4.11.1", [
+        (lambda v: v == "4.11.1", True),
+        (lambda v: v < "4.11.1", False),
+        (lambda v: v > "4.11.1", False),
+        (lambda v: v < "5.0.0", True),
+        (lambda v: v > "4.11.0", True),
+        (lambda v: v > "4.9.3", True),
+        (lambda v: v == packaging.version.Version("4.11.1"), True),
+    ]),
+    ("5.0.0a2", [
+        (lambda v: v == "5.0.0", False),
+        (lambda v: v < "5.0.0", True),
+        (lambda v: v > "4.11.1", True),
+        (lambda v: v > "5.0.0a1", True),
+        (lambda v: v == "5.0.0a2", True),
+        (lambda v: v < "5.0.0b1", True),
+    ]),
+])
+def test_version(vstr, checks):
+    """Test class Version.
+    """
+    version = Version(vstr)
+    for check, res in checks:
+        assert check(version) == res


### PR DESCRIPTION
Drop `distutils.version.StrictVersion` deprecated since Python 3.10 in favour of our own helper class `archive.tools.Version` based on `packaging.version.Version`.  Obviously, this adds another dependency on `packaging`.