### PR TITLE
Add command line flag --ignore-mtime to archive-tool check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changelog
 0.7 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~
 
+New features
+------------
+
++ `#76`_, `#77`_: Add a command line flag `--ignore-mtime` to
+  `archive-tool check` to ignore the file modification time in the
+  checks.
+
 Bug fixes and minor changes
 ---------------------------
 
@@ -22,6 +29,8 @@ Internal changes
 
 .. _#74: https://github.com/RKrahl/archive-tools/pull/74
 .. _#75: https://github.com/RKrahl/archive-tools/pull/75
+.. _#76: https://github.com/RKrahl/archive-tools/issues/76
+.. _#77: https://github.com/RKrahl/archive-tools/pull/77
 
 
 0.6 (2021-12-12)

--- a/tests/test_04_cli_check.py
+++ b/tests/test_04_cli_check.py
@@ -183,7 +183,6 @@ def test_check_present_symlink_target(test_dir, copy_data, monkeypatch):
         f.seek(0)
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
-@pytest.mark.xfail(reason="Issue #76")
 def test_check_ignore_mtime(test_dir, copy_data, monkeypatch):
     monkeypatch.chdir(copy_data)
     fp = Path("base", "data", "rnd.dat")

--- a/tests/test_04_cli_check.py
+++ b/tests/test_04_cli_check.py
@@ -183,6 +183,18 @@ def test_check_present_symlink_target(test_dir, copy_data, monkeypatch):
         f.seek(0)
         assert set(get_output(f)) == all_test_files - {str(fp)}
 
+@pytest.mark.xfail(reason="Issue #76")
+def test_check_ignore_mtime(test_dir, copy_data, monkeypatch):
+    monkeypatch.chdir(copy_data)
+    fp = Path("base", "data", "rnd.dat")
+    fp.touch()
+    with TemporaryFile(mode="w+t", dir=test_dir) as f:
+        args = ["check", "--ignore-mtime",
+                str(test_dir / "archive.tar"), "base"]
+        callscript("archive-tool.py", args, stdout=f)
+        f.seek(0)
+        assert set(get_output(f)) == set()
+
 def test_check_extract_archive(test_dir, extract_archive, monkeypatch):
     """When extracting an archive and checking the result, 
     check should not report any file to be missing in the archive.


### PR DESCRIPTION
Add a flag `--ignore-mtime` to the command line of the `archive-tool check` subcommand. If provided, the modification time is ignored when checking whether a file is in the archive.

Close #76.