### PR TITLE
Simplify tmp_chdir() and tmp_umask() using contextlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Internal changes
 ----------------
 
 + `#74`_, `#80`_: Review build tool chain.
++ `#83`_: Simplify implementation of :func:`archive.tools.tmp_chdir`
+  and :func:`archive.tools.tmp_umask` using :mod:`contextlib`.
 
 .. _#74: https://github.com/RKrahl/archive-tools/pull/74
 .. _#75: https://github.com/RKrahl/archive-tools/pull/75
@@ -37,6 +39,7 @@ Internal changes
 .. _#80: https://github.com/RKrahl/archive-tools/pull/80
 .. _#81: https://github.com/RKrahl/archive-tools/issues/81
 .. _#82: https://github.com/RKrahl/archive-tools/pull/82
+.. _#83: https://github.com/RKrahl/archive-tools/pull/83
 
 
 0.6 (2021-12-12)

--- a/src/archive/tools.py
+++ b/src/archive/tools.py
@@ -6,6 +6,7 @@
    keep anything in here compatible between different versions.
 """
 
+from contextlib import contextmanager
 import datetime
 import hashlib
 import os
@@ -93,41 +94,27 @@ class Version(packaging.version.Version):
         return super().__ne__(other)
 
 
-class tmp_chdir():
+@contextmanager
+def tmp_chdir(dir):
     """A context manager to temporarily change directory.
     """
-    def __init__(self, dir):
-        self.save_dir = None
-        self.dir = dir
-    def __enter__(self):
-        self.save_dir = os.getcwd()
-        os.chdir(self.dir)
-    def _restore_dir(self):
-        if self.save_dir:
-            os.chdir(self.save_dir)
-        self.save_dir = None
-    def __exit__(self, type, value, tb):
-        self._restore_dir()
-    def __del__(self):
-        self._restore_dir()
+    save_dir = os.getcwd()
+    os.chdir(dir)
+    try:
+        yield dir
+    finally:
+        os.chdir(save_dir)
 
 
-class tmp_umask():
+@contextmanager
+def tmp_umask(mask):
     """A context manager to temporarily set the umask.
     """
-    def __init__(self, mask):
-        self.save_mask = None
-        self.mask = mask
-    def __enter__(self):
-        self.save_mask = os.umask(self.mask)
-    def _restore_mask(self):
-        if self.save_mask:
-            os.umask(self.save_mask)
-        self.save_mask = None
-    def __exit__(self, type, value, tb):
-        self._restore_mask()
-    def __del__(self):
-        self._restore_mask()
+    save_mask = os.umask(mask)
+    try:
+        yield mask
+    finally:
+        os.umask(save_mask)
 
 
 def date_str_rfc5322(dt):


### PR DESCRIPTION
Simplify implementation of `archive.tools.tmp_chdir()` and `archive.tools.tmp_umask()` using `contextlib`.